### PR TITLE
CLI and progress bar for downloads

### DIFF
--- a/metadata_test.py
+++ b/metadata_test.py
@@ -1,0 +1,7 @@
+import h5py
+
+
+with h5py.File(
+    "/home/rodrigo/.minari/datasets/hammer-human-v0/data/main_data.hdf5", "r"
+) as f:
+    print(dict(f.attrs.items()))

--- a/metadata_test.py
+++ b/metadata_test.py
@@ -1,7 +1,0 @@
-import h5py
-
-
-with h5py.File(
-    "/home/rodrigo/.minari/datasets/hammer-human-v0/data/main_data.hdf5", "r"
-) as f:
-    print(dict(f.attrs.items()))

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -1,44 +1,30 @@
+"""Minari CLI commands."""
 from typing import List, Optional
 
 import typer
+from rich import print
 from rich.console import Console
 from rich.table import Table
+from rich.tree import Tree
 
 from minari import __version__
-from minari.storage import hosting, local
+from minari.minari_dataset import combine_datasets
+from minari.storage import get_dataset_path, hosting, local
 
 
 app = typer.Typer()
+list_app = typer.Typer()
+app.add_typer(list_app, name="list", short_help="List Minari datasets.")
 
 
-def version_callback(value: bool):
+def _version_callback(value: bool):
+    """Show installed Minari version."""
     if value:
         typer.echo(f"Minari version: {__version__}")
         raise typer.Exit()
 
 
-@app.callback()
-def common(
-    version: Optional[bool] = typer.Option(
-        None, "--version", "-v", callback=version_callback
-    )
-):
-    """Minari is a tool for collecting and hosting Offline datasets for Reinforcement Learning environments based on the Gymnaisum API."""
-    pass
-
-
-@app.command()
-def list(storage: str):
-    """List Minari datasets."""
-    table_title = " "
-    if storage == "remote":
-        datasets = hosting.list_remote_datasets()
-        table_title = "Minari datasets in Farama server"
-    else:
-        datasets = local.list_local_datasets()
-        dataset_dir = "home/rodrigo/.minari/"
-        table_title = f"Local Minari datasets('{dataset_dir}')"
-
+def _show_dataset_table(datasets, table_title):
     table = Table(title=table_title)
 
     table.add_column("Name", justify="left", style="cyan", no_wrap=True)
@@ -65,17 +51,95 @@ def list(storage: str):
     console.print(table)
 
 
+@app.callback()
+def common(
+    version: Optional[bool] = typer.Option(
+        None, "--version", "-v", callback=_version_callback
+    )
+):
+    """Minari is a tool for collecting and hosting Offline datasets for Reinforcement Learning environments based on the Gymnaisum API."""
+    pass
+
+
+@list_app.command("remote")
+def list_remote():
+    """List Minari datasets hosted in the Farama server."""
+    datasets = hosting.list_remote_datasets()
+    table_title = "Minari datasets in Farama server"
+    _show_dataset_table(datasets, table_title)
+
+
+@list_app.command("local")
+def list_local():
+    """List local Minari datasets."""
+    datasets = local.list_local_datasets()
+    dataset_dir = "home/rodrigo/.minari/"
+    table_title = f"Local Minari datasets('{dataset_dir}')"
+    _show_dataset_table(datasets, table_title)
+
+
 @app.command()
 def delete(datasets: List[str]):
     """Delete datasets from local database."""
+    # check that the given local datasets exist
+    local_dsts = local.list_local_datasets()
+    non_matching_local = [dst for dst in datasets if dst not in local_dsts]
+    if len(non_matching_local) > 0:
+        local_dataset_path = get_dataset_path("")
+        tree = Tree(
+            f"The following datasets can't be found locally at `{local_dataset_path}`",
+            style="red",
+        )
+        for dst in non_matching_local:
+            tree.add(dst, style="magenta")
+        print(tree)
+        raise typer.Abort()
+
+    # prompt to delete datasets
+    datasets_to_delete = {
+        local_name: local_dsts[local_name]
+        for local_name in local_dsts.keys()
+        if local_name in datasets
+    }
+    _show_dataset_table(datasets_to_delete, "Delete local Minari datasets")
+    typer.confirm("Are you sure you want to delete these local datasets?", abort=True)
+
     for dst in datasets:
         local.delete_dataset(dst)
 
 
 @app.command()
 def download(datasets: List[str]):
+    """Download Minari datasets from Farama server."""
+    # check if datasets exist in remote server
+    remote_dsts = hosting.list_remote_datasets()
+    non_matching_remote = [dst for dst in datasets if dst not in remote_dsts]
+    if len(non_matching_remote) > 0:
+        tree = Tree(
+            "The following datasets can't be found in the remote Farama server",
+            style="red",
+        )
+        for dst in non_matching_remote:
+            tree.add(dst, style="magenta")
+        print(tree)
+        raise typer.Abort()
+
     # check existing datasets locally and ask again if you want them to be overridden
-    # check if datasets exist in remote server, if not
+    local_dsts = local.list_local_datasets()
+    datasets_to_override = {
+        local_name: local_dsts[local_name]
+        for local_name in local_dsts.keys()
+        if local_name in datasets
+    }
+
+    if len(datasets_to_override) > 0:
+        _show_dataset_table(datasets_to_override, "Download remote Minari datasets")
+        typer.confirm(
+            "Are you sure you want to download and override these local datasets?",
+            abort=True,
+        )
+
+    # download datastets
     for dst in datasets:
         hosting.download_dataset(dst)
 
@@ -83,14 +147,77 @@ def download(datasets: List[str]):
 @app.command()
 def upload(datasets: List[str], key_path: str = typer.Option(...)):
     """Upload Minari datasets to the remote Farama server."""
+    local_dsts = local.list_local_datasets()
+    remote_dsts = hosting.list_remote_datasets()
+
+    # check that the given local datasets exist
+    non_matching_local = [dst for dst in datasets if dst not in local_dsts]
+    if len(non_matching_local) > 0:
+        local_dataset_path = get_dataset_path("")
+        tree = Tree(
+            f"The following datasets can't be found locally at `{local_dataset_path}`",
+            style="red",
+        )
+        for dst in non_matching_local:
+            tree.add(dst, style="magenta")
+        print(tree)
+        raise typer.Abort()
+
+    # check that non of the datasets exist in the Farama server
+    matching_remote = {
+        remote_name: remote_dsts[remote_name]
+        for remote_name in remote_dsts.keys()
+        if remote_name in datasets
+    }
+    if len(matching_remote) > 0:
+        console = Console()
+        console.print(
+            "The following datasets are already present in the Farama server, please contact the Farama team at contact@farama.org to upload your datasets.",
+            style="red",
+        )
+        _show_dataset_table(matching_remote, "Matching datasets in Farama server")
+        raise typer.Abort()
+
+    # Upload datasets
     for dst in datasets:
         hosting.upload_dataset(dst, key_path)
 
 
 @app.command()
-def combine(dataset_name, datasets):
+def combine(datasets: List[str], dataset_name: str = typer.Option(...)):
+    """Combine multiple datasets into a single Minari dataset."""
+    local_dsts = local.list_local_datasets()
+    # check dataset name doesn't exist locally
+    if dataset_name in local_dsts:
+        console = Console()
+        console.print(
+            f"Dataset name {dataset_name} already exist in the local Minari datasets.",
+            style="red",
+        )
+        raise typer.Abort()
 
-    pass
+    # check list of local datasets to combine exist
+    non_matching_local = [dst for dst in datasets if dst not in local_dsts]
+    if len(non_matching_local) > 0:
+        local_dataset_path = get_dataset_path("")
+        tree = Tree(
+            f"The following datasets can't be found locally at `{local_dataset_path}`",
+            style="red",
+        )
+        for dst in non_matching_local:
+            tree.add(dst, style="magenta")
+        print(tree)
+        raise typer.Abort()
+    if len(datasets) > 1:
+        minari_datasets = list(map(lambda x: local.load_dataset(x), datasets))
+        combine_datasets(minari_datasets, dataset_name)
+    else:
+        console = Console()
+        console.print(
+            f"The list of local datasets to combine {datasets} must be of size two or greater.",
+            style="red",
+        )
+        raise typer.Abort()
 
 
 if __name__ == "__main__":

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -1,0 +1,93 @@
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+import minari
+from minari import __version__
+from minari.storage import hosting, local
+
+
+app = typer.Typer()
+
+
+def version_callback(value: bool):
+    if value:
+        typer.echo(f"Minari version: {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def common(
+    version: Optional[bool] = typer.Option(
+        None, "--version", "-v", callback=version_callback
+    )
+):
+    """Minari is a tool for collecting and hosting Offline datasets for Reinforcement Learning environments based on the Gymnaisum API."""
+    pass
+
+
+@app.command()
+def list(storage: str):
+    """List Minari datasets."""
+    if storage == "remote":
+        hosting.list_remote_datasets()
+    elif storage == "local":
+        local_dataset_names = local.list_local_datasets(verbose=False)
+        dataset_dir = "home/rodrigo/.minari/"
+        table = Table(title=f"Local Minari datasets('{dataset_dir}')")
+
+        table.add_column("Name", justify="left", style="cyan", no_wrap=True)
+        table.add_column("Total Episodes", justify="right", style="green")
+        table.add_column("Total Steps", justify="right", style="green")
+        table.add_column("Description", justify="left", style="magenta")
+        table.add_column("Author", justify="left", style="magenta")
+        table.add_column("Email", justify="left", style="magenta")
+
+        for dst in map(lambda x: minari.load_dataset(x), local_dataset_names):
+
+            table.add_row(
+                dst.name,
+                str(dst.total_episodes),
+                str(dst.total_steps),
+                " ",
+                dst.author,
+                dst.email,
+            )
+
+        console = Console()
+        console.print(table)
+    else:
+        pass
+
+
+@app.command()
+def delete(datasets: List[str]):
+    """Delete datasets from local database."""
+    for dst in datasets:
+        local.delete_dataset(dst)
+
+
+@app.command()
+def download(datasets: List[str]):
+    # check existing datasets locally and ask again if you want them to be overridden
+    # check if datasets exist in remote server, if not
+    for dst in datasets:
+        hosting.download_dataset(dst)
+
+
+@app.command()
+def upload(datasets: List[str]):
+    """Upload Minari datasets to the remote Farama server."""
+    pass
+
+
+@app.command()
+def combine(dataset_name, datasets):
+
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -54,7 +54,11 @@ def _show_dataset_table(datasets, table_title):
 @app.callback()
 def common(
     version: Optional[bool] = typer.Option(
-        None, "--version", "-v", callback=_version_callback
+        None,
+        "--version",
+        "-v",
+        callback=_version_callback,
+        help="Show installed Minari version.",
     )
 ):
     """Minari is a tool for collecting and hosting Offline datasets for Reinforcement Learning environments based on the Gymnaisum API."""

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -4,7 +4,6 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-import minari
 from minari import __version__
 from minari.storage import hosting, local
 
@@ -31,35 +30,39 @@ def common(
 @app.command()
 def list(storage: str):
     """List Minari datasets."""
+    table_title = " "
     if storage == "remote":
-        hosting.list_remote_datasets()
-    elif storage == "local":
-        local_dataset_names = local.list_local_datasets(verbose=False)
-        dataset_dir = "home/rodrigo/.minari/"
-        table = Table(title=f"Local Minari datasets('{dataset_dir}')")
-
-        table.add_column("Name", justify="left", style="cyan", no_wrap=True)
-        table.add_column("Total Episodes", justify="right", style="green")
-        table.add_column("Total Steps", justify="right", style="green")
-        table.add_column("Description", justify="left", style="magenta")
-        table.add_column("Author", justify="left", style="magenta")
-        table.add_column("Email", justify="left", style="magenta")
-
-        for dst in map(lambda x: minari.load_dataset(x), local_dataset_names):
-
-            table.add_row(
-                dst.name,
-                str(dst.total_episodes),
-                str(dst.total_steps),
-                " ",
-                dst.author,
-                dst.email,
-            )
-
-        console = Console()
-        console.print(table)
+        datasets = hosting.list_remote_datasets()
+        table_title = "Minari datasets in Farama server"
     else:
-        pass
+        datasets = local.list_local_datasets()
+        dataset_dir = "home/rodrigo/.minari/"
+        table_title = f"Local Minari datasets('{dataset_dir}')"
+
+    table = Table(title=table_title)
+
+    table.add_column("Name", justify="left", style="cyan", no_wrap=True)
+    table.add_column("Total Episodes", justify="right", style="green")
+    table.add_column("Total Steps", justify="right", style="green")
+    table.add_column("Description", justify="left", style="yellow")
+    table.add_column("Author", justify="left", style="magenta")
+    table.add_column("Email", justify="left", style="magenta")
+
+    for dst_metadata in datasets.values():
+        assert isinstance(dst_metadata["dataset_name"], str)
+        assert isinstance(dst_metadata["author"], str)
+        assert isinstance(dst_metadata["author_email"], str)
+        table.add_row(
+            dst_metadata["dataset_name"],
+            str(dst_metadata["total_episodes"]),
+            str(dst_metadata["total_steps"]),
+            "Coming soon ...",
+            dst_metadata["author"],
+            dst_metadata["author_email"],
+        )
+
+    console = Console()
+    console.print(table)
 
 
 @app.command()
@@ -78,9 +81,10 @@ def download(datasets: List[str]):
 
 
 @app.command()
-def upload(datasets: List[str]):
+def upload(datasets: List[str], key_path: str = typer.Option(...)):
     """Upload Minari datasets to the remote Farama server."""
-    pass
+    for dst in datasets:
+        hosting.upload_dataset(dst, key_path)
 
 
 @app.command()

--- a/minari/minari_dataset.py
+++ b/minari/minari_dataset.py
@@ -41,6 +41,9 @@ class MinariDataset:
             self._observation_space = env.observation_space
             self._action_space = env.action_space
 
+            self._author = f.attrs["author"]
+            self._author_email = f.attrs["author_email"]
+
             env.close()
 
         self._episode_idx = list(range(self._total_episodes))
@@ -79,12 +82,12 @@ class MinariDataset:
         return self._data_path
 
     @property
-    def total_steps(self):
+    def total_steps(self) -> int:
         """Total steps recorded in the Minari dataset along all episodes."""
         return self._total_steps
 
     @property
-    def total_episodes(self):
+    def total_episodes(self) -> int:
         """Total episodes recorded in the Minari dataset."""
         return self._total_episodes
 
@@ -97,9 +100,17 @@ class MinariDataset:
             return self._combined_datasets
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Name of the Minari dataset."""
         return self._dataset_name
+
+    @property
+    def author(self) -> str:
+        return self._author
+
+    @property
+    def email(self) -> str:
+        return self._author_email
 
     def _filter_episode_group(
         self, condition_func: Callable[[h5py.Group], bool], hdf5_file: h5py.File

--- a/minari/minari_dataset.py
+++ b/minari/minari_dataset.py
@@ -154,7 +154,7 @@ class MinariDataset:
             self._episode_idx = list(filter(condition_func, self._episode_idx))
 
         self._total_episodes = len(self._episode_idx)
-        "TODO: return new updated Minari dataset object instead of "
+        "TODO: return new updated Minari dataset object instead of updating the current object"
 
     def shuffle_episodes(self, seed: Optional[int] = None):
         """Suffle the episode iterator for sampling.

--- a/minari/minari_dataset.py
+++ b/minari/minari_dataset.py
@@ -452,6 +452,7 @@ def create_dataset_from_buffers(
             "`code_permalink` is set to None. For reproducibility purposes it is highly recommended to link your dataset to versioned code.",
             UserWarning,
         )
+
     if author is None:
         warnings.warn(
             "`author` is set to None. For longevity purposes it is highly recommended to provide an author name.",
@@ -512,6 +513,9 @@ def create_dataset_from_buffers(
                 "env_spec"
             ] = env.spec.to_json()  # pyright: ignore [reportOptionalMemberAccess]
             file.attrs["dataset_name"] = dataset_name
+            file.attrs["author"] = str(author)
+            file.attrs["author_email"] = str(author_email)
+            file.attrs["code_permalink"] = str(code_permalink)
 
         return MinariDataset(data_path)
     else:

--- a/minari/storage/__init__.py
+++ b/minari/storage/__init__.py
@@ -1,0 +1,1 @@
+from minari.storage.datasets_root_dir import get_dataset_path

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -85,9 +85,10 @@ def download_dataset(dataset_name: str):
 
         # See https://github.com/googleapis/python-storage/issues/27 for discussion on progress bars
         for blob in blobs:
-            if blob.name.endswith("/"):
-                # Don't download empty folders
-                continue
+            print("DOWNLOADING NAME AND SIZE")
+            print(blob.name)
+            print(blob.size)
+
             blob_dir, file_name = os.path.split(blob.name)
             blob_local_dir = os.path.join(os.path.dirname(file_path), blob_dir)
             if not os.path.exists(blob_local_dir):

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -39,13 +39,16 @@ def upload_dataset(dataset_name: str, path_to_private_key: str):
         )
         bucket = storage.Bucket(storage_client, "minari-datasets")
 
+        dataset = load_dataset(dataset_name)
+
         # See https://github.com/googleapis/python-storage/issues/27 for discussion on progress bars
         _upload_local_directory_to_gcs(str(file_path), bucket, dataset_name)
 
         print(f"Dataset {dataset_name} uploaded!")
 
-        combined_datasets = load_dataset(dataset_name).combined_datasets
-        if len(combined_datasets) > 0:
+        combined_datasets = dataset.combined_datasets
+
+        if len(dataset.combined_datasets) > 0:
             print(
                 f"Dataset {dataset_name} is formed by a combination of the following datasets:"
             )

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+from typing import Dict, Union
+
+import h5py
 
 from minari.minari_dataset import MinariDataset
 from minari.storage.datasets_root_dir import get_dataset_path
@@ -19,24 +22,24 @@ def load_dataset(dataset_name: str):
     return MinariDataset(data_path)
 
 
-def list_local_datasets(verbose=True):
-    """Get a list of all the Minari dataset names in the local database.
-
-    Args:
-        verbose (bool, optional): If True the dataset names will be shown in the command line. Defaults to True.
+def list_local_datasets() -> Dict[str, Dict[str, Union[str, int, bool]]]:
+    """Get a the names and metadata of all the Minari datasets in the local database.
 
     Returns:
-       list[str]: List of local Minari dataset name id's
+       Dict[str, Dict[str, str]]: keys the names of the Minari datasets and values the metadata
     """
     datasets_path = get_dataset_path("")
-    datasets = sorted([dir_name for dir_name in os.listdir(datasets_path)])
+    dataset_names = sorted([dir_name for dir_name in os.listdir(datasets_path)])
 
-    if verbose:
-        print("Datasets found locally:")
-        for dataset in datasets:
-            print(dataset)
+    local_datasets = {}
+    for dst_name in dataset_names:
+        main_file_path = os.path.join(datasets_path, dst_name, "data/main_data.hdf5")
 
-    return datasets
+        with h5py.File(main_file_path, "r") as f:
+            metadata = dict(f.attrs.items())
+            local_datasets[dst_name] = metadata
+
+    return local_datasets
 
 
 def delete_dataset(dataset_name: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "numpy >=1.21.0",
     "h5py==3.7.0",
+    "tqdm>=4.65.0",
     "typing_extensions==4.4.0",
     "google-cloud-storage==2.5.0",
     "typer[all]==0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "h5py==3.7.0",
     "typing_extensions==4.4.0",
     "google-cloud-storage==2.5.0",
+    "typer[all]==0.7.0",
     "gymnasium @ git+https://github.com/pseudo-rnd-thoughts/Gymnasium.git@spec_stack",
 ]
 dynamic = ["version"]
@@ -46,8 +47,9 @@ Repository = "https://github.com/Farama-Foundation/Minari"
 Documentation = "https://minari.farama.org/"
 "Bug Report" = "https://github.com/Farama-Foundation/Minari/issues"
 
-[project.entry-points."console_scripts"]
-minari = "mianri.__init__:register_robotics_envs"
+
+[project.scripts]
+minari = "minari.cli:app"
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ Repository = "https://github.com/Farama-Foundation/Minari"
 Documentation = "https://minari.farama.org/"
 "Bug Report" = "https://github.com/Farama-Foundation/Minari/issues"
 
+[project.entry-points."console_scripts"]
+minari = "mianri.__init__:register_robotics_envs"
+
 [tool.setuptools]
 include-package-data = true
 


### PR DESCRIPTION
# Description
This PR adds a progress bar to each file download when downloading a Minari dataset from the Farama server. It also adds CLI commands for Minari using [`Typer`](https://typer.tiangolo.com/).

- `list`: list of all the minari datasets with some metadata. It has other two subcommands to list remote or local datasets, `minari list remote` and `minari list local`
![image](https://user-images.githubusercontent.com/60633730/223247386-534d6038-23ad-4a30-986d-a05bab9fe7be.png)

- `delete`: delete local Minari datasets given a list of dataset names, `minari delete door-expert-v0 door-human-v0`
- `download`: download a list of remote Minari datasets, `minari download pen-expert-v0 pen-human-v0 pen-cloned-v0`
- `upload`: upload a list of local datasets to remote Farama server, json key is required. `minari upload door-expert-v0 door-human-v0 --key-path /home/user/key_file.json`
- `combine`: combine multiple local datasets into a single Minari dataset with a unique name, `minari combine door-expert-v0 door-human-v0 --dataset-name all-door-v0`

## Type of change

> Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
