### PR TITLE
Fixes to DataCollectorV0

### DIFF
--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -246,9 +246,9 @@ class DataCollectorV0(gym.Wrapper):
 
         assert STEP_DATA_KEYS.issubset(step_data.keys())
 
-        # If last episode in global buffer has saved steps
+        # If last episode in global buffer has saved steps, we need to check if it was truncated or terminated
+        # If not, then we need to auto-truncate the episode
         if len(self._buffer[-1]["actions"]) > 0:
-            # If the last episode is not term/trunc then truncate the episode
             if (
                 not self._buffer[-1]["terminations"][-1]
                 and not self._buffer[-1]["truncations"][-1]

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -33,6 +33,10 @@ def list_local_datasets() -> Dict[str, Dict[str, Union[str, int, bool]]]:
 
     local_datasets = {}
     for dst_name in dataset_names:
+        if "data" not in os.listdir(os.path.join(datasets_path, dst_name)):
+            # Minari datasets must contain the data directory.
+            continue
+
         main_file_path = os.path.join(datasets_path, dst_name, "data/main_data.hdf5")
 
         with h5py.File(main_file_path, "r") as f:


### PR DESCRIPTION
# Description
This PR adds some fixes to the data collector wrapper `DataCollectorV0`:
- Increase the `_episode_id` of the `DataCollectorV0` only after the buffers are cleared when calling `clear_buffers_to_tmp_file`. Before, if the buffers were cleared and the last episode was `terminated` or `truncated`, `_episode_id` would have increased by one and an additional empty episode was included in the dataset.
- When updating a dataset with new data (from `DataCollectorV0`) add the hdf5 group links iterating through the episode id's instead of the hdf5 file episode groups. This way we make sure that the episode groups are ordered by id
- When listing local datasets only list dataset directories that include a `data/` directory

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
