### PR TITLE
Add dataset statistics computation method

### DIFF
--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -313,7 +313,7 @@ class MinariDataset:
             )
 
     def compute_stats(self) -> Dict[str, Dict[str, np.ndarray]]:
-        """Compute statistics the dataset.
+        """Compute statistics of the dataset.
 
         Returns:
             Dictionary containing statistics for observations, rewards and actions.

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -318,28 +318,28 @@ class MinariDataset:
         Returns:
             Dictionary containing statistics for observations, rewards and actions.
         """
-        datasets_to_compute = ["observations", "rewards", "actions"]
+        data_to_targe = ["observations", "rewards", "actions"]
         stats = {}
-        for dataset_name in datasets_to_compute:
-            stats[dataset_name] = self._compute_dataset_stats(dataset_name)
+        for data_name in data_to_targe:
+            stats[data_name] = self._compute_data_stats(data_name)
 
         return stats
 
-    def _compute_dataset_stats(self, dataset_name: str) -> Dict[str, Any]:
-        episode_data = self._data.apply(
-            lambda episode: episode[dataset_name][()], self.episode_indices
+    def _compute_data_stats(self, data_name: str) -> Dict[str, Any]:
+        data = self._data.apply(
+            lambda episode: episode[data_name][()], self.episode_indices
         )
-        episode_data = np.concatenate(episode_data, axis=0)
-        if len(episode_data.shape) == 1:
-            histograms = np.histogram(episode_data, bins=20)
+        data = np.concatenate(data, axis=0)
+        if len(data.shape) == 1:
+            histograms = np.histogram(data, bins=20)
         else:
             histograms = []
-            for i in range(episode_data.shape[1]):
-                histograms.append(np.histogram(episode_data[:, i], bins=20))
+            for i in range(data.shape[1]):
+                histograms.append(np.histogram(data[:, i], bins=20))
         return {
-            "mean": np.mean(episode_data, axis=0),
-            "std": np.std(episode_data, axis=0),
-            "min": np.min(episode_data, axis=0),
-            "max": np.max(episode_data, axis=0),
+            "mean": np.mean(data, axis=0),
+            "std": np.std(data, axis=0),
+            "min": np.min(data, axis=0),
+            "max": np.max(data, axis=0),
             "histogram": histograms,
         }

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -331,7 +331,7 @@ class MinariDataset:
         )
         data = np.concatenate(data, axis=0)
         if len(data.shape) == 1:
-            histograms = np.histogram(data, bins=20)
+            histograms = [np.histogram(data, bins=20)]
         else:
             histograms = []
             for i in range(data.shape[1]):

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -318,9 +318,9 @@ class MinariDataset:
         Returns:
             Dictionary containing statistics for observations, rewards and actions.
         """
-        data_to_targe = ["observations", "rewards", "actions"]
+        data_to_target = ["observations", "rewards", "actions"]
         stats = {}
-        for data_name in data_to_targe:
+        for data_name in data_to_target:
             stats[data_name] = self._compute_data_stats(data_name)
 
         return stats

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -1,0 +1,126 @@
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import gymnasium
+import numpy as np
+import pytest
+
+import minari
+from minari.dataset.minari_dataset import MinariDataset
+
+
+@pytest.mark.parametrize("environment_id", ["CartPole-v1", "Blackjack-v1"])
+@pytest.mark.parametrize("num_episodes", [1, 10])
+def test_compute_stats(tmp_path, environment_id, num_episodes):
+    """Test the computation of dataset statistics."""
+    dataset_id = "test-dataset-v0"
+    dataset, buffers = _generate_local_minari_dataset(
+        dataset_id, environment_id, num_episodes, tmp_path
+    )
+
+    expected_stats = {}
+    expected_stats["actions"] = _compute_expected_stats(buffers, "actions")
+    expected_stats["observations"] = _compute_expected_stats(buffers, "observations")
+    expected_stats["rewards"] = _compute_expected_stats(buffers, "rewards")
+
+    computed_stats = dataset.compute_stats()
+
+    for key, value in computed_stats.items():
+        assert np.array_equal(value["mean"], expected_stats[key]["mean"])
+        assert np.array_equal(value["std"], expected_stats[key]["std"])
+        assert np.array_equal(value["max"], expected_stats[key]["max"])
+        assert np.array_equal(value["min"], expected_stats[key]["min"])
+        assert len(value["histogram"]) == len(expected_stats[key]["histogram"])
+        for i, histogram in enumerate(value["histogram"]):
+            assert np.array_equal(histogram[0], expected_stats[key]["histogram"][i][0])
+            assert np.array_equal(histogram[1], expected_stats[key]["histogram"][i][1])
+
+
+def _compute_expected_stats(buffers: List[Dict[str, np.ndarray]], target_data: str):
+    """Compute the stats over the complete data given a list of episode data."""
+    data = np.concatenate([buffer[target_data] for buffer in buffers], axis=0)
+    if len(data.shape) == 1:
+        histograms = [np.histogram(data, bins=20)]
+    else:
+        num_variables = data.shape[1]
+        histograms = [np.histogram(data[:, i], bins=20) for i in range(num_variables)]
+    return {
+        "mean": np.mean(data, axis=0),
+        "std": np.std(data, axis=0),
+        "min": np.min(data, axis=0),
+        "max": np.max(data, axis=0),
+        "histogram": histograms,
+    }
+
+
+def _generate_local_minari_dataset(
+    dataset_id: str, environment_id: str, num_episodes: int, dataset_path: Path
+) -> Tuple[MinariDataset, List[Dict[str, np.ndarray]]]:
+    """Generate a local MinariDataset from a Gymnasium environment.
+
+    Args:
+        dataset_id: ID of the newly created dataset.
+        environment_id: ID of the Gymnasium environment to use for data generation.
+        num_episodeds: The number of episodes to generate data for.
+        dataset_path: Path to local folder where to create dataset files.
+
+    Returns:
+        A tuple containing the MinariDataset and the data used to create it.
+    """
+    os.environ["MINARI_DATASETS_PATH"] = dataset_path.as_posix()
+    buffers = []
+    env = gymnasium.make(environment_id)
+
+    observations = []
+    actions = []
+    rewards = []
+    terminations = []
+    truncations = []
+
+    observation, _ = env.reset(seed=42)
+
+    observation, _ = env.reset()
+    observations.append(observation)
+    for _ in range(num_episodes):
+        terminated = False
+        truncated = False
+
+        while not terminated and not truncated:
+            action = env.action_space.sample()
+            observation, reward, terminated, truncated, _ = env.step(action)
+            observations.append(observation)
+            actions.append(action)
+            rewards.append(reward)
+            terminations.append(terminated)
+            truncations.append(truncated)
+
+        episode_buffer = {
+            "observations": np.asarray(observations),
+            "actions": np.asarray(actions),
+            "rewards": np.asarray(rewards),
+            "terminations": np.asarray(terminations),
+            "truncations": np.asarray(truncations),
+        }
+        buffers.append(episode_buffer)
+
+        observations.clear()
+        actions.clear()
+        rewards.clear()
+        terminations.clear()
+        truncations.clear()
+
+        observation, _ = env.reset()
+        observations.append(observation)
+
+    # Create Minari dataset and store locally
+    dataset = minari.create_dataset_from_buffers(
+        dataset_id=dataset_id,
+        env=env,
+        buffer=buffers,
+        algorithm_name="test_policy",
+        code_permalink="https://test.com",
+        author="Minari",
+        author_email="minari@farama.org",
+    )
+    return dataset, buffers


### PR DESCRIPTION
# Description

Add a method to compute basic statistics of a dataset based on [method from d3rlpy repo](https://github.com/takuseno/d3rlpy/blob/a11b15db1e60d47296fdc7e7880fe1165803138a/d3rlpy/dataset.pyx#L336).


## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
