### PR TITLE
General cleanup

### DIFF
--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
-from typing import Any, Dict, List, Optional, SupportsFloat, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, SupportsFloat, Type, Union
 
 import gymnasium as gym
 import h5py
@@ -18,7 +18,8 @@ from minari.data_collector.callbacks import (
 )
 
 
-EpisodeBuffer = dict[str, list | dict | int | str]
+EpisodeBuffer = Dict[str, Any]  # TODO: narrow this down
+
 
 class DataCollectorV0(gym.Wrapper):
     r"""Gymnasium environment wrapper that collects step data.
@@ -169,6 +170,7 @@ class DataCollectorV0(gym.Wrapper):
                         episode_buffer[key], value
                     )
                 else:
+                    assert isinstance(episode_buffer[key], list)
                     episode_buffer[key].append(value)
 
         return episode_buffer
@@ -216,7 +218,7 @@ class DataCollectorV0(gym.Wrapper):
             self._previous_eps_final_obs = step_data["observations"]
             self._reset_called = False
             self._new_episode = True
-            self._buffer[-1]["seed"] = self._current_seed
+            self._buffer[-1]["seed"] = self._current_seed  # type: ignore
             # Only check episode scheduler to save in-memory data to temp HDF5 file when episode is done
             if self.max_buffer_episodes is not None:
                 clear_buffers = (self._episode_id + 1) % self.max_buffer_episodes == 0
@@ -255,7 +257,7 @@ class DataCollectorV0(gym.Wrapper):
                 and not self._buffer[-1]["truncations"][-1]
             ):
                 self._buffer[-1]["truncations"][-1] = True
-                self._buffer[-1]["seed"] = self._current_seed
+                self._buffer[-1]["seed"] = self._current_seed  # type: ignore
 
                 # New episode
                 self._episode_id += 1
@@ -407,7 +409,7 @@ class DataCollectorV0(gym.Wrapper):
         # Clear in-memory buffers
         self._buffer.clear()
 
-    def save_to_disk(self, path: str, dataset_metadata: dict | None = None):
+    def save_to_disk(self, path: str, dataset_metadata: Optional[Dict] = None):
         """Save all in-memory buffer data and move temporary HDF5 file to a permanent location in disk.
 
         Args:

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -127,6 +127,7 @@ class DataCollectorV0(gym.Wrapper):
         self._tmp_f.attrs["flatten_action"] = self._step_data_callback.flatten_action
 
         self._new_episode = False
+        self._reset_called = False
 
         # Initialize first episode group in temporary hdf5 file
         self._episode_id = 0
@@ -406,13 +407,16 @@ class DataCollectorV0(gym.Wrapper):
         # Clear in-memory buffers
         self._buffer.clear()
 
-    def save_to_disk(self, path: str, dataset_metadata: Dict = {}):
+    def save_to_disk(self, path: str, dataset_metadata: dict | None = None):
         """Save all in-memory buffer data and move temporary HDF5 file to a permanent location in disk.
 
         Args:
             path (str): path to store permanent HDF5, i.e: '/home/foo/datasets/data.hdf5'
             dataset_metadata (Dict, optional): additional metadata to add to HDF5 dataset file as attributes. Defaults to {}.
         """
+        if dataset_metadata is None:
+            dataset_metadata = {}
+
         # Dump everything in memory buffers to tmp_dataset.hdf5 and truncate last episode
         self.clear_buffer_to_tmp_file(truncate_last_episode=True)
 

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -18,7 +18,7 @@ from minari.data_collector.callbacks import (
 )
 
 
-EpisodeBuffer = dict[str, list | dict]
+EpisodeBuffer = dict[str, list | dict | int | str]
 
 class DataCollectorV0(gym.Wrapper):
     r"""Gymnasium environment wrapper that collects step data.

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -18,9 +18,7 @@ from minari.data_collector.callbacks import (
 )
 
 
-EpisodeBufferValues = TypeVar("EpisodeBufferValues", List[Any], "EpisodeBuffer")
-EpisodeBuffer = Dict[str, EpisodeBufferValues]
-
+EpisodeBuffer = dict[str, list | dict]
 
 class DataCollectorV0(gym.Wrapper):
     r"""Gymnasium environment wrapper that collects step data.
@@ -86,7 +84,7 @@ class DataCollectorV0(gym.Wrapper):
         Raises:
             ValueError: `max_buffer_steps` and `max_buffer_episodes` can't be passed at the same time
         """
-        self.env = env
+        super().__init__(env)
         self._step_data_callback = step_data_callback(env)
 
         self._episode_metadata_callback = episode_metadata_callback()
@@ -146,7 +144,7 @@ class DataCollectorV0(gym.Wrapper):
         """Add step data dictionary to episode buffer.
 
         Args:
-            buffer (Dict): dictionary episode buffer
+            episode_buffer (Dict): dictionary episode buffer
             step_data (Dict): dictionary with data for a single step
 
         Returns:
@@ -191,8 +189,8 @@ class DataCollectorV0(gym.Wrapper):
             truncated=truncated,
         )
 
-        # force step data dicitonary to include keys corresponding to Gymnasium step returns:
-        # actions, observations, rewards, terminations, truncatins, and infos
+        # force step data dictionary to include keys corresponding to Gymnasium step returns:
+        # actions, observations, rewards, terminations, truncations, and infos
         assert STEP_DATA_KEYS.issubset(step_data.keys())
 
         self._step_id += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "typing_extensions==4.4.0",
     "google-cloud-storage==2.5.0",
     "typer[all]==0.7.0",
-    "gymnasium @ git+https://github.com/Farama-Foundation/Gymnasium.git@main",
+    "gymnasium>=0.28.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
I'm going through the repository and fixing whatever minor issues I spot. For now I'm not doing anything significant, but I'll write down potentially more complex things that need to be fixed before a full release

- data_collector.py#L102 -- self._current_seed has type `str | int`, which seems a bit sus
- data_collectory.py#L140 -- There has to be a simpler way of writing this using defaultdict or setdefault or something like that
- data_collector.py#L66-69 -- Can't the type hints be simple callables?
- The type hint for EpisodeBuffer is meant (?) to convey that it's a nested dictionary where leaves are lists. This doesn't work because `self._current_seed: int | str` is one of the possible top-level values