### PR TITLE
fix incorrect path printing in the cli

### DIFF
--- a/minari/cli.py
+++ b/minari/cli.py
@@ -77,7 +77,8 @@ def list_local():
     """List local Minari datasets."""
     datasets = local.list_local_datasets()
     dataset_dir = os.environ.get(
-        "MINARI_DATASETS_PATH", os.path.join(os.path.expanduser("~"), ".minari")
+        "MINARI_DATASETS_PATH",
+        os.path.join(os.path.expanduser("~"), ".minari/datasets/"),
     )
     table_title = f"Local Minari datasets('{dataset_dir}')"
     _show_dataset_table(datasets, table_title)

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -1,4 +1,5 @@
 """Minari CLI commands."""
+import os
 from typing import List, Optional
 
 import typer
@@ -75,7 +76,9 @@ def list_remote():
 def list_local():
     """List local Minari datasets."""
     datasets = local.list_local_datasets()
-    dataset_dir = "home/rodrigo/.minari/"
+    dataset_dir = os.environ.get(
+        "MINARI_DATASETS_PATH", os.path.join(os.path.expanduser("~"), ".minari")
+    )
     table_title = f"Local Minari datasets('{dataset_dir}')"
     _show_dataset_table(datasets, table_title)
 


### PR DESCRIPTION
# Description

Previously, it showed the wrong path to datasets for `minari list local` cli command.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

### Screenshots
<img width="837" alt="Screenshot 2023-05-28 at 18 00 34" src="https://github.com/Farama-Foundation/Minari/assets/25152289/0fd25c1d-0dca-49f9-b126-e2682b1ec993">

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

