### PR TITLE
added check to ensure observation and action at each index is in the …

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -435,10 +435,10 @@ def check_data_integrity(data: MinariStorage, episode_indices: Iterable[int]):
             obs = _reconstuct_obs_or_action_at_index_recursive(
                 episode["observations"], i
             )
-            assert obs in data.observation_space
+            assert data.observation_space.contains(obs)
         for i in range(episode["total_timesteps"]):
             action = _reconstuct_obs_or_action_at_index_recursive(episode["actions"], i)
-            assert action in data.action_space
+            assert data.action_space.contains(action)
 
         assert episode["total_timesteps"] == len(episode["rewards"])
         assert episode["total_timesteps"] == len(episode["terminations"])

--- a/tests/common.py
+++ b/tests/common.py
@@ -447,7 +447,7 @@ def check_data_integrity(data: MinariStorage, episode_indices: Iterable[int]):
 
 def _reconstuct_obs_or_action_at_index_recursive(
     data: Union[dict, tuple, np.ndarray], index: int
-):
+) -> Union[np.ndarray, dict, tuple]:
     if isinstance(data, dict):
         return {
             key: _reconstuct_obs_or_action_at_index_recursive(data[key], index)


### PR DESCRIPTION
…observation space when sliced out of the array format

# Description

In our dataset standard update PR https://github.com/Farama-Foundation/Minari/pull/77, we provide observations and actions as either a single `np.ndarray`, or as a single dict or tuple containing a `np.ndarray` for each component of the action space(possibly with nested `tuple`s and `dict`s). In an earlier version of the standard change, we previously provided observations and actions as a list of observations and actions, such that `assert obs in data.observation_space` would pass for the dataset. This PR adds a check to construct observations and actions from the new format in a way where we can check if they are in the observation and action spaces. 


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
