### PR TITLE
Ruggedize list_remote_datasets

### DIFF
--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import glob
 import os
+import warnings
 from typing import Dict
 
 import h5py
@@ -141,15 +142,13 @@ def list_remote_datasets() -> Dict[str, Dict[str, str]]:
 
     blobs = storage_client.list_blobs(bucket_or_name="minari-datasets")
 
-    remote_datasets_metadata = list(
-        map(
-            lambda x: x.metadata,
-            filter(lambda x: x.name.endswith("main_data.hdf5"), blobs),
-        )
-    )
     remote_datasets = {}
-    for metadata in remote_datasets_metadata:
-        remote_datasets[metadata["dataset_id"]] = metadata
+    for blob in blobs:
+        try:
+            if blob.name.endswith("main_data.hdf5"):
+                remote_datasets[blob.metadata["dataset_id"]] = blob.metadata
+        except Exception:
+            warnings.warn(f"Misconfigured dataset named {blob.name} on remote")
 
     return remote_datasets
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -435,10 +435,10 @@ def check_data_integrity(data: MinariStorage, episode_indices: Iterable[int]):
             obs = _reconstuct_obs_or_action_at_index_recursive(
                 episode["observations"], i
             )
-            assert obs in data.observation_space
+            assert data.observation_space.contains(obs)
         for i in range(episode["total_timesteps"]):
             action = _reconstuct_obs_or_action_at_index_recursive(episode["actions"], i)
-            assert action in data.action_space
+            assert data.action_space.contains(action)
 
         assert episode["total_timesteps"] == len(episode["rewards"])
         assert episode["total_timesteps"] == len(episode["terminations"])

--- a/tests/common.py
+++ b/tests/common.py
@@ -447,7 +447,7 @@ def check_data_integrity(data: MinariStorage, episode_indices: Iterable[int]):
 
 def _reconstuct_obs_or_action_at_index_recursive(
     data: Union[dict, tuple, np.ndarray], index: int
-):
+) -> Union[np.ndarray, dict, tuple]:
     if isinstance(data, dict):
         return {
             key: _reconstuct_obs_or_action_at_index_recursive(data[key], index)


### PR DESCRIPTION
# Description

Ruggedizes `list_remote_datasets`so it will not crash as easily if there is a misconfigured dataset in minari remote storage.

#Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
