### PR TITLE
ignore hidden files when listing local datasets

### DIFF
--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -29,7 +29,13 @@ def list_local_datasets() -> Dict[str, Dict[str, Union[str, int, bool]]]:
        Dict[str, Dict[str, str]]: keys the names of the Minari datasets and values the metadata
     """
     datasets_path = get_dataset_path("")
-    dataset_ids = sorted([dir_name for dir_name in os.listdir(datasets_path)])
+    dataset_ids = sorted(
+        [
+            dir_name
+            for dir_name in os.listdir(datasets_path)
+            if not dir_name.startswith(".")
+        ]
+    )
 
     local_datasets = {}
     for dst_id in dataset_ids:


### PR DESCRIPTION
# Description

This PR fixes the .DS_Store issue mentioned in #97 . When accessing the local Minari datasets folder on MacOS a `.DS_Store` file gets automatically created which causes the `minari.list_local_datasets` function to fail with the following error:
```
  File "/Users/username/minari/storage/local.py", line 36, in list_local_datasets
    if "data" not in os.listdir(os.path.join(datasets_path, dst_id)):
NotADirectoryError: [Errno 20] Not a directory: '/Users/username/.minari/datasets/.DS_Store'
```

The implemented fix modifies the `minari.list_local_datasets` function so that it ignores hidden files when trying to list local datasets. 

Fixes #97

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have run `pytest -v` and no errors are present.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
