### PR TITLE
Minari version specifiers

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
-          python: 37
           platform: manylinux_x86_64
         - os: ubuntu-latest
           python: 38

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -502,6 +502,7 @@ When creating a Minari dataset with the `DataCollectorV0` wrapper the default gl
 | `algorithm_name`        | `str`      | Name of the expert policy used to create the dataset. |
 | `action_space`          | `str`      | Serialized Gymnasium action space describing actions in dataset. |
 | `observation_space`     | `str`      | Serialized Gymnasium observation space describing observations in dataset. |
+| `minari_version`        | `str`      | Version specifier of Minari versions compatible with the dataset. |
 
 
 

--- a/docs/content/minari_cli.md
+++ b/docs/content/minari_cli.md
@@ -52,7 +52,14 @@ The `minari list COMMAND` command shows a table with the existing Minari dataset
 This command comes with other two required sub-commands:
 
 - `remote`: the Minari dataset table shows the datasets currently available in the remote Farama server.
-- `local`: the Minari dataset table shows the datasets currently accessible in the local device. 
+- `local`: the Minari dataset table shows the datasets currently accessible in the local device.
+
+```{eval-rst}
+
+.. note::
+   These commands will list the latest remote/local dataset versions that are compatible with your local installed Minari version. To list all the dataset versions (also incompatible) add the option :code:`--all` or :code:`-a` to the command.
+
+```
 
 <div class="termy">
 
@@ -92,6 +99,13 @@ $ minari list remote
 
 With the command `minari download DATASETS` you can download a group of datasets that are available in the remote Farama server. If the dataset name already exist locally, the Minari CLI will prompt you to override the
 current content of the local dataset.
+
+```{eval-rst}
+
+.. note::
+   The download is aborted if the remote dataset is not compatible with your local installed Minari version or through a warning if the dataset already exists locally. To perform a force download add :code:`--force` or :code: `-f` to the download command.
+
+```
 
 <div class="termy">
 

--- a/minari/__init__.py
+++ b/minari/__init__.py
@@ -38,4 +38,4 @@ __all__ = [
     "get_normalized_score",
 ]
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -75,7 +75,7 @@ def list_remote():
 
 
 @list_app.command("local")
-def list_local():
+def list_local(all: Optional[bool] = typer.Option(False)):
     """List local Minari datasets."""
     datasets = local.list_local_datasets(
         latest_version=False, compatible_minari_version=False

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -136,7 +136,12 @@ def delete(datasets: Annotated[List[str], typer.Argument()]):
 
 
 @app.command()
-def download(datasets: Annotated[List[str], typer.Argument()]):
+def download(
+    datasets: Annotated[List[str], typer.Argument()],
+    force: Annotated[
+        bool, typer.Option("--force", "-f", help="Perform a force download.")
+    ] = False,
+):
     """Download Minari datasets from Farama server."""
     # check if datasets exist in remote server
     remote_dsts = hosting.list_remote_datasets()
@@ -160,7 +165,7 @@ def download(datasets: Annotated[List[str], typer.Argument()]):
         if local_name in datasets
     }
 
-    if len(datasets_to_override) > 0:
+    if len(datasets_to_override) > 0 and not force:
         _show_dataset_table(datasets_to_override, "Download remote Minari datasets")
         typer.confirm(
             "Are you sure you want to download and override these local datasets?",
@@ -169,7 +174,7 @@ def download(datasets: Annotated[List[str], typer.Argument()]):
 
     # download datastets
     for dst in datasets:
-        hosting.download_dataset(dst, force_download=True)
+        hosting.download_dataset(dst, force_download=force)
 
 
 @app.command()

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -1,6 +1,7 @@
 """Minari CLI commands."""
 import os
 from typing import List, Optional
+from typing_extensions import Annotated
 
 import typer
 from rich import print
@@ -65,21 +66,35 @@ def common(
 
 
 @list_app.command("remote")
-def list_remote():
+def list_remote(
+    all: Annotated[
+        bool, typer.Option("--all", "-a", help="Show all dataset versions.")
+    ] = False
+):
     """List Minari datasets hosted in the Farama server."""
-    datasets = hosting.list_remote_datasets(
-        latest_version=True, compatible_minari_version=True
-    )
+    if all:
+        datasets = hosting.list_remote_datasets()
+    else:
+        datasets = hosting.list_remote_datasets(
+            latest_version=True, compatible_minari_version=True
+        )
     table_title = "Minari datasets in Farama server"
     _show_dataset_table(datasets, table_title)
 
 
 @list_app.command("local")
-def list_local(all: Optional[bool] = typer.Option(False)):
+def list_local(
+    all: Annotated[
+        bool, typer.Option("--all", "-a", help="Show all dataset versions.")
+    ] = False
+):
     """List local Minari datasets."""
-    datasets = local.list_local_datasets(
-        latest_version=False, compatible_minari_version=False
-    )
+    if all:
+        datasets = local.list_local_datasets()
+    else:
+        datasets = local.list_local_datasets(
+            latest_version=True, compatible_minari_version=True
+        )
     dataset_dir = os.environ.get(
         "MINARI_DATASETS_PATH",
         os.path.join(os.path.expanduser("~"), ".minari/datasets/"),

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -67,7 +67,9 @@ def common(
 @list_app.command("remote")
 def list_remote():
     """List Minari datasets hosted in the Farama server."""
-    datasets = hosting.list_remote_datasets()
+    datasets = hosting.list_remote_datasets(
+        latest_version=True, compatible_minari_version=True
+    )
     table_title = "Minari datasets in Farama server"
     _show_dataset_table(datasets, table_title)
 

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -77,7 +77,9 @@ def list_remote():
 @list_app.command("local")
 def list_local():
     """List local Minari datasets."""
-    datasets = local.list_local_datasets()
+    datasets = local.list_local_datasets(
+        latest_version=False, compatible_minari_version=False
+    )
     dataset_dir = os.environ.get(
         "MINARI_DATASETS_PATH",
         os.path.join(os.path.expanduser("~"), ".minari/datasets/"),
@@ -121,6 +123,7 @@ def download(datasets: List[str]):
     """Download Minari datasets from Farama server."""
     # check if datasets exist in remote server
     remote_dsts = hosting.list_remote_datasets()
+
     non_matching_remote = [dst for dst in datasets if dst not in remote_dsts]
     if len(non_matching_remote) > 0:
         tree = Tree(

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -53,13 +53,15 @@ def _show_dataset_table(datasets, table_title):
 
 @app.callback()
 def common(
-    version: Optional[bool] = typer.Option(
-        None,
-        "--version",
-        "-v",
-        callback=_version_callback,
-        help="Show installed Minari version.",
-    )
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--version",
+            "-v",
+            callback=_version_callback,
+            help="Show installed Minari version.",
+        ),
+    ] = None,
 ):
     """Minari is a tool for collecting and hosting Offline datasets for Reinforcement Learning environments based on the Gymnaisum API."""
     pass
@@ -104,7 +106,7 @@ def list_local(
 
 
 @app.command()
-def delete(datasets: List[str]):
+def delete(datasets: Annotated[List[str], typer.Argument()]):
     """Delete datasets from local database."""
     # check that the given local datasets exist
     local_dsts = local.list_local_datasets()
@@ -134,7 +136,7 @@ def delete(datasets: List[str]):
 
 
 @app.command()
-def download(datasets: List[str]):
+def download(datasets: Annotated[List[str], typer.Argument()]):
     """Download Minari datasets from Farama server."""
     # check if datasets exist in remote server
     remote_dsts = hosting.list_remote_datasets()
@@ -171,7 +173,10 @@ def download(datasets: List[str]):
 
 
 @app.command()
-def upload(datasets: List[str], key_path: str = typer.Option(...)):
+def upload(
+    datasets: Annotated[List[str], typer.Argument()],
+    key_path: Annotated[str, typer.Option()],
+):
     """Upload Minari datasets to the remote Farama server."""
     local_dsts = local.list_local_datasets()
     remote_dsts = hosting.list_remote_datasets()
@@ -208,7 +213,10 @@ def upload(datasets: List[str], key_path: str = typer.Option(...)):
 
 
 @app.command()
-def combine(datasets: List[str], dataset_id: str = typer.Option(...)):
+def combine(
+    datasets: Annotated[List[str], typer.Argument()],
+    dataset_id: Annotated[str, typer.Option()],
+):
     """Combine multiple datasets into a single Minari dataset."""
     local_dsts = local.list_local_datasets()
     # check dataset name doesn't exist locally

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -19,7 +19,7 @@ DATASET_ID_RE = re.compile(
 )
 
 
-def parse_dataset_id(dataset_id: str) -> tuple[str | None, str, int | None]:
+def parse_dataset_id(dataset_id: str) -> tuple[str | None, str, int]:
     """Parse dataset ID string format - ``(env_name-)(dataset_name)(-v(version))``.
 
     Args:
@@ -35,8 +35,8 @@ def parse_dataset_id(dataset_id: str) -> tuple[str | None, str, int | None]:
             f"Malformed dataset ID: {dataset_id}. (Currently all IDs must be of the form (env_name-)(dataset_name)-v(version). (namespace is optional))"
         )
     env_name, dataset_name, version = match.group("environment", "dataset", "version")
-    if version is not None:
-        version = int(version)
+
+    version = int(version)
 
     return env_name, dataset_name, version
 

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -111,7 +111,6 @@ class MinariDatasetSpec:
         self.env_name, self.dataset_name, self.version = parse_dataset_id(
             self.dataset_id
         )
-        
 
 
 class MinariDataset:
@@ -163,7 +162,7 @@ class MinariDataset:
             observation_space=self._data.observation_space,
             action_space=self._data.action_space,
             data_path=str(self._data.data_path),
-            
+            minari_version=str(self._data.minari_version),
         )
         self._total_steps = total_steps
         self._generator = np.random.default_rng()

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -99,6 +99,7 @@ class MinariDatasetSpec:
     observation_space: gym.Space
     action_space: gym.Space
     data_path: str
+    minari_version: str
 
     # post-init attributes
     env_name: str | None = field(init=False)
@@ -110,6 +111,7 @@ class MinariDatasetSpec:
         self.env_name, self.dataset_name, self.version = parse_dataset_id(
             self.dataset_id
         )
+        
 
 
 class MinariDataset:
@@ -161,6 +163,7 @@ class MinariDataset:
             observation_space=self._data.observation_space,
             action_space=self._data.action_space,
             data_path=str(self._data.data_path),
+            
         )
         self._total_steps = total_steps
         self._generator = np.random.default_rng()

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -8,7 +8,8 @@ import gymnasium as gym
 import h5py
 import numpy as np
 from gymnasium.envs.registration import EnvSpec
-from packaging import version
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 from minari.data_collector import DataCollectorV0
 from minari.serialization import deserialize_space
@@ -48,8 +49,8 @@ class MinariStorage:
             assert isinstance(minari_version, str)
 
             # Check that the dataset is compatible with the current version of Minari
-            assert version.parse(__version__) == version.parse(
-                minari_version
+            assert Version(__version__) in SpecifierSet(
+            minari_version
             ), f'Dataset {dataset_id} is compatible with Minari version {minari_version}. The Minari version of your system is {__version__}. Please install the appropriate version of Minari through : "pip install minari=={minari_version}'
             self._minari_version = minari_version
 

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -11,6 +11,10 @@ from gymnasium.envs.registration import EnvSpec
 from minari.data_collector import DataCollectorV0
 from minari.serialization import deserialize_space
 
+import importlib.metadata
+
+# Use importlib due to circular import when: "from minari import __version__"
+__version__ = importlib.metadata.version('minari')
 
 PathLike = Union[str, bytes, os.PathLike]
 
@@ -38,6 +42,12 @@ class MinariStorage:
             dataset_id = f.attrs["dataset_id"]
             assert isinstance(dataset_id, str)
             self._dataset_id = dataset_id
+
+            minari_version = f.attrs["minari_version"]
+            assert isinstance(minari_version, str)
+
+            # Check that the dataset is compatible with the current version of Minari
+            assert version.parse(__version__) == version.parse(minari_version), f'Dataset {dataset_id} is compatible with Minari version {minari_version}. The Minari version of your system is {__version__}. Please install the appropiate version of Minari through : "pip install minari=={minari_version}'
 
             self._combined_datasets = f.attrs.get("combined_datasets", default=[])
 

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -50,7 +50,7 @@ class MinariStorage:
 
             # Check that the dataset is compatible with the current version of Minari
             assert Version(__version__) in SpecifierSet(
-            minari_version
+                minari_version
             ), f'Dataset {dataset_id} is compatible with Minari version {minari_version}. The Minari version of your system is {__version__}. Please install the appropriate version of Minari through : "pip install minari=={minari_version}'
             self._minari_version = minari_version
 

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import json
 import os
 from collections import OrderedDict
@@ -7,14 +8,14 @@ import gymnasium as gym
 import h5py
 import numpy as np
 from gymnasium.envs.registration import EnvSpec
+from packaging import version
 
 from minari.data_collector import DataCollectorV0
 from minari.serialization import deserialize_space
 
-import importlib.metadata
 
 # Use importlib due to circular import when: "from minari import __version__"
-__version__ = importlib.metadata.version('minari')
+__version__ = importlib.metadata.version("minari")
 
 PathLike = Union[str, bytes, os.PathLike]
 
@@ -47,7 +48,10 @@ class MinariStorage:
             assert isinstance(minari_version, str)
 
             # Check that the dataset is compatible with the current version of Minari
-            assert version.parse(__version__) == version.parse(minari_version), f'Dataset {dataset_id} is compatible with Minari version {minari_version}. The Minari version of your system is {__version__}. Please install the appropiate version of Minari through : "pip install minari=={minari_version}'
+            assert version.parse(__version__) == version.parse(
+                minari_version
+            ), f'Dataset {dataset_id} is compatible with Minari version {minari_version}. The Minari version of your system is {__version__}. Please install the appropriate version of Minari through : "pip install minari=={minari_version}'
+            self._minari_version = minari_version
 
             self._combined_datasets = f.attrs.get("combined_datasets", default=[])
 

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -245,7 +245,10 @@ def list_remote_datasets(
             env_name, dataset_name, version = parse_dataset_id(dataset_id)
             dataset = f"{env_name}-{dataset_name}"
             if latest_version:
-                if dataset not in remote_datasets or version > remote_datasets[dataset][0]:
+                if (
+                    dataset not in remote_datasets
+                    or version > remote_datasets[dataset][0]
+                ):
                     remote_datasets[dataset] = (version, metadata)
             else:
                 remote_datasets[dataset_id] = metadata

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -92,16 +92,29 @@ def download_dataset(dataset_id: str, force_download: bool = False):
     """
 
     # Check if minari version is compatible with dataset
-    download_env_name, download_dataset_name, _ = parse_dataset_id(dataset_id)
+    download_env_name, download_dataset_name, download_version = parse_dataset_id(dataset_id)
     remote_dataset_ids = list_remote_datasets(compatible_minari_version=True).keys()
     
-    # If dataset_id not in remote, version not compatible. Check if there are any compatible versions.
+    # If dataset_id not in remote, version is not compatible. Check and suggest other compatible versions.
     if dataset_id not in remote_dataset_ids:
         available_versions = []
         for id in remote_dataset_ids:
             env_name, dataset_name, version = parse_dataset_id(id)
             if download_env_name == env_name and download_dataset_name == dataset_name:
                 available_versions.append(version)
+            
+        if available_versions:
+            available_datasets = [f'{download_env_name}-{download_dataset_name}-v{version}' for version in available_versions]
+            raise ValueError(f"The version you are trying to download for this dataset, v{download_version}, is not compatible with\
+                                your local installed version of Minari, {__version__}. We found other dataset versions that are compatible: {', '.join(available_datasets)}")
+        else:
+            raise ValueError(f"No datasets or other versions of it were found for dataset id {dataset_id} in the Farama server. Are you sure\
+                                this is the dataset you are looking for?")
+
+    higher_version = find_highest_remote_version(download_env_name, download_dataset_name, True)
+    if higher_version > download_version:
+        logger.warn(f"We recommend you install a higher dataset version available and compatible with your local installed Minari version: {download_env_name}-{download_dataset_name}-v{higher_version}.")
+    
     file_path = get_dataset_path(dataset_id)
     if os.path.exists(file_path):
         if not force_download:
@@ -136,6 +149,7 @@ def download_dataset(dataset_id: str, force_download: bool = False):
 
     print(f"\nDataset {dataset_id} downloaded to {file_path}")
 
+    # 
     combined_datasets = load_dataset(dataset_id).spec.combined_datasets
 
     # If the dataset is a combination of other datasets download the subdatasets recursively

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -92,8 +92,16 @@ def download_dataset(dataset_id: str, force_download: bool = False):
     """
 
     # Check if minari version is compatible with dataset
+    download_env_name, download_dataset_name, _ = parse_dataset_id(dataset_id)
     remote_dataset_ids = list_remote_datasets(compatible_minari_version=True).keys()
-    # if dataset_id not in remote_dataset_ids:
+    
+    # If dataset_id not in remote, version not compatible. Check if there are any compatible versions.
+    if dataset_id not in remote_dataset_ids:
+        available_versions = []
+        for id in remote_dataset_ids:
+            env_name, dataset_name, version = parse_dataset_id(id)
+            if download_env_name == env_name and download_dataset_name == dataset_name:
+                available_versions.append(version)
     file_path = get_dataset_path(dataset_id)
     if os.path.exists(file_path):
         if not force_download:
@@ -171,7 +179,7 @@ def list_remote_datasets(
     return remote_datasets
 
 
-def find_highest_remote_version(env_name: str, dataset_name: str) -> int | None:
+def find_highest_remote_version(env_name: str, dataset_name: str, compatible_minari_version: bool = False) -> int | None:
     """Finds the highest registered version in the remote Farama server of the dataset given.
 
     Args:
@@ -182,7 +190,7 @@ def find_highest_remote_version(env_name: str, dataset_name: str) -> int | None:
     """
     version: list[int] = []
 
-    for dataset_id in list_remote_datasets().keys():
+    for dataset_id in list_remote_datasets(compatible_minari_version).keys():
         remote_env_name, remote_dataset_name, remote_version = parse_dataset_id(
             dataset_id
         )

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -218,7 +218,7 @@ def list_remote_datasets(
     """Get the names and metadata of all the Minari datasets in the remote Farama server.
 
     Args:
-        latest_version (bool): if `True` only the latest version of the datasets are returned i.e. from ['door-human-v0', 'door-human-v1`], only the metadata for v1 is returned. Default to `False`
+        latest_version (bool): if `True` only the latest version of the datasets are returned i.e. from ['door-human-v0', 'door-human-v1`], only the metadata for v1 is returned. Default to `False`.
         compatible_minari_version (bool): if `True` only the datasets compatible with the current Minari version are returned. Default to `False`.
 
     Returns:
@@ -249,11 +249,6 @@ def list_remote_datasets(
         except Exception:
             warnings.warn(f"Misconfigured dataset named {blob.name} on remote")
 
-    assert bool(remote_datasets), (
-        "No datasets were found in the remote Farama server with the specified coniguration: "
-        f"`compatible_minari_version = {compatible_minari_version}, `latest_version` = {latest_version}."
-    )
-
     # Return dict = {'dataset_id': metadata}
     return dict(map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), remote_datasets.items()))
 
@@ -272,7 +267,7 @@ def get_remote_dataset_versions(
         latest_version (bool): if `True` only the latest version of the datasets is returned. Default to `False`.
         compatible_minari_version: only return highest version among the datasets compatible with the local installed version of Minari. Default to `False`
     Returns:
-        The highest version of a dataset with matching environment name and name, otherwise ``None`` is returned.
+        A list of integer versions of the dataset with the specified requirements.
     """
     versions: list[int] = []
 

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -244,16 +244,21 @@ def list_remote_datasets(
             dataset_id = metadata["dataset_id"]
             env_name, dataset_name, version = parse_dataset_id(dataset_id)
             dataset = f"{env_name}-{dataset_name}"
-            if latest_version and dataset in remote_datasets:
-                if version > remote_datasets[dataset][0]:
+            if latest_version:
+                if dataset not in remote_datasets or version > remote_datasets[dataset][0]:
                     remote_datasets[dataset] = (version, metadata)
             else:
-                remote_datasets[dataset] = (version, metadata)
+                remote_datasets[dataset_id] = metadata
         except Exception:
             warnings.warn(f"Misconfigured dataset named {blob.name} on remote")
 
-    # Return dict = {'dataset_id': metadata}
-    return dict(map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), remote_datasets.items()))
+    if latest_version:
+        # Return dict = {'dataset_id': metadata}
+        return dict(
+            map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), remote_datasets.items())
+        )
+    else:
+        return remote_datasets
 
 
 def get_remote_dataset_versions(

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -249,6 +249,11 @@ def list_remote_datasets(
         except Exception:
             warnings.warn(f"Misconfigured dataset named {blob.name} on remote")
 
+    assert bool(remote_datasets), (
+        "No datasets were found in the remote Farama server with the specified coniguration: "
+        f"`compatible_minari_version = {compatible_minari_version}, `latest_version` = {latest_version}."
+    )
+
     # Return dict = {'dataset_id': metadata}
     return dict(map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), remote_datasets.items()))
 

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -233,7 +233,7 @@ def list_remote_datasets(
 
     # Generate dict = {'env_name-dataset_name': (version, metadata)}
     remote_datasets = {}
-    for prefix in blobs.prefixes:
+    for prefix in sorted(blobs.prefixes):
         blob = bucket.get_blob(prefix)
         try:
             metadata = blob.metadata

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -228,6 +228,9 @@ def list_remote_datasets(
     bucket = client.bucket("minari-datasets")
     blobs = bucket.list_blobs(delimiter="main_data.hdf5")
 
+    # Necessary to get prefixes iterable
+    next(blobs)
+
     # Generate dict = {'env_name-dataset_name': (version, metadata)}
     remote_datasets = {}
     for prefix in blobs.prefixes:

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -74,6 +74,7 @@ def list_local_datasets(
             else:
                 local_datasets[dst_id] = metadata
     if latest_version:
+        # Return dict = {'dataset_id': metadata}
         return dict(
             map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), local_datasets.items())
         )

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -57,7 +57,6 @@ def list_local_datasets(
             continue
 
         main_file_path = os.path.join(datasets_path, dst_id, "data/main_data.hdf5")
-
         with h5py.File(main_file_path, "r") as f:
             metadata = dict(f.attrs.items())
             if compatible_minari_version and __version__ not in SpecifierSet(
@@ -66,13 +65,20 @@ def list_local_datasets(
                 continue
             env_name, dataset_name, version = parse_dataset_id(dst_id)
             dataset = f"{env_name}-{dataset_name}"
-            if latest_version and dataset in local_datasets:
-                if version > local_datasets[dataset][0]:
+            if latest_version:
+                if (
+                    dataset not in local_datasets
+                    or version > local_datasets[dataset][0]
+                ):
                     local_datasets[dataset] = (version, metadata)
             else:
-                local_datasets[dataset] = (version, metadata)
-
-    return dict(map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), local_datasets.items()))
+                local_datasets[dst_id] = metadata
+    if latest_version:
+        return dict(
+            map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), local_datasets.items())
+        )
+    else:
+        return local_datasets
 
 
 def delete_dataset(dataset_id: str):

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -14,7 +14,7 @@ import h5py
 import numpy as np
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.registration import EnvSpec
-from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
 
 from minari import DataCollectorV0
@@ -441,7 +441,7 @@ def create_dataset_from_buffers(
         )
     # Check if the installed Minari version falls inside the minari_version specifier
     try:
-        assert Version(__version__) in Specifier(
+        assert Version(__version__) in SpecifierSet(
             minari_version
         ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
     except InvalidSpecifier:
@@ -602,7 +602,7 @@ def create_dataset_from_collector_env(
         )
     # Check if the installed Minari version falls inside the minari_version specifier
     try:
-        assert Version(__version__) in Specifier(
+        assert Version(__version__) in SpecifierSet(
             minari_version
         ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
     except InvalidSpecifier:

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -87,7 +87,9 @@ def combine_minari_version_specifiers(specifier_set: SpecifierSet):
     final_version_specifier = SpecifierSet()
 
     if inclusion_interval.lower == inclusion_interval.upper:
-        assert inclusion_interval.lower == __version__
+        assert inclusion_interval.lower == Version(
+            __version__
+        ), f"The local installed version of Minari, {__version__}, must comply with the equality version specifier: =={inclusion_interval.lower}"
         final_version_specifier &= f"=={inclusion_interval.lower}"
         # There is just one compatible version of Minari
         return final_version_specifier

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -27,7 +27,7 @@ from minari.storage.datasets_root_dir import get_dataset_path
 __version__ = importlib.metadata.version("minari")
 
 
-def combine_minari_version_specifiers(specifier_set: SpecifierSet):
+def combine_minari_version_specifiers(specifier_set: SpecifierSet) -> SpecifierSet:
     """Calculates the Minari version specifier by intersecting a group of Minari version specifiers.
 
     Used to calculate the `minari_version` metadata attribute when combining multiple datasets. The function
@@ -152,7 +152,7 @@ def combine_minari_version_specifiers(specifier_set: SpecifierSet):
     return final_version_specifier
 
 
-def validate_datasets_to_combine(datasets_to_combine: List[MinariDataset]):
+def validate_datasets_to_combine(datasets_to_combine: List[MinariDataset]) -> EnvSpec:
     """Check if the given datasets can be combined.
 
     Tests if the datasets were created with the same environment (`env_spec`) and re-calculates the
@@ -184,8 +184,7 @@ def validate_datasets_to_combine(datasets_to_combine: List[MinariDataset]):
         combine_env_spec.append(dataset_env_spec)
 
     assert all(
-        env_spec == combine_env_spec[0]
-        for env_spec in combine_env_spec
+        env_spec == combine_env_spec[0] for env_spec in combine_env_spec
     ), "The datasets to be combined have different values for `env_spec` attribute."
 
     return combine_env_spec[0]

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -5,14 +5,14 @@ import importlib.metadata
 import os
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
-import portion as P
-import copy
 
 import gymnasium as gym
 import h5py
 import numpy as np
+import portion as P
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.registration import EnvSpec
+from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
 
@@ -510,7 +510,7 @@ def create_dataset_from_buffers(
                 file.attrs["ref_max_score"] = ref_max_score
                 file.attrs["ref_min_score"] = ref_min_score
                 file.attrs["num_episodes_average_score"] = num_episodes_average_score
-            
+
             file["minari_version"] = minari_version
 
         return MinariDataset(data_path)
@@ -531,7 +531,7 @@ def create_dataset_from_collector_env(
     ref_max_score: Optional[float] = None,
     expert_policy: Optional[Callable[[ObsType], ActType]] = None,
     num_episodes_average_score: int = 100,
-    minari_version: Optional[str] = None
+    minari_version: Optional[str] = None,
 ):
     """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollectorV0` Minari wrapper.
 

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -14,7 +14,8 @@ import h5py
 import numpy as np
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.registration import EnvSpec
-from gymnasium.wrappers import RecordEpisodeStatistics
+from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
+from packaging.version import Version
 
 from minari import DataCollectorV0
 from minari.dataset.minari_dataset import MinariDataset
@@ -437,9 +438,12 @@ def create_dataset_from_buffers(
         minari_version = f"=={__version__}"
     else:
         # Check if the installed Minari version falls inside the minari_version specifier
-        assert Version(__version__) in SpecifierSet(
-            minari_version
-        ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
+        try:
+            assert Version(__version__) in Specifier(
+                minari_version
+            ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
+        except InvalidSpecifier:
+            print(f"{minari_version} is not a version specifier.")
 
     if observation_space is None:
         observation_space = env.observation_space
@@ -593,9 +597,12 @@ def create_dataset_from_collector_env(
         minari_version = f"=={__version__}"
     else:
         # Check if the installed Minari version falls inside the minari_version specifier
-        assert Version(__version__) in SpecifierSet(
-            minari_version
-        ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
+        try:
+            assert Version(__version__) in Specifier(
+                minari_version
+            ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
+        except InvalidSpecifier:
+            print(f"{minari_version} is not a version specifier.")
 
     assert collector_env.datasets_path is not None
     dataset_path = os.path.join(collector_env.datasets_path, dataset_id)

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -432,7 +432,7 @@ def create_dataset_from_buffers(
             f"`minari_version` is set to None. The compatible dataset version specifier for Minari will be automatically fixed to the installed version {__version__}.",
             UserWarning,
         )
-        minari_version = __version__
+        minari_version = f"=={__version__}"
     else:
         # Check if the installed Minari version falls inside the minari_version specifier
         assert Version(__version__) in SpecifierSet(
@@ -588,7 +588,7 @@ def create_dataset_from_collector_env(
             f"`minari_version` is set to None. The compatible dataset version specifier for Minari will be automatically fixed to the installed version {__version__}.",
             UserWarning,
         )
-        minari_version = __version__
+        minari_version = f"=={__version__}"
     else:
         # Check if the installed Minari version falls inside the minari_version specifier
         assert Version(__version__) in SpecifierSet(

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -230,7 +230,6 @@ def combine_datasets(
     Returns:
         combined_dataset (MinariDataset): the resulting MinariDataset
     """
-
     combined_dataset_env_spec = validate_datasets_to_combine(datasets_to_combine)
 
     # Compute intersection of Minari version specifiers

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import importlib.metadata
 import os
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -18,15 +19,16 @@ from minari.dataset.minari_storage import clear_episode_buffer
 from minari.serialization import serialize_space
 from minari.storage.datasets_root_dir import get_dataset_path
 
-import importlib.metadata
 
 # Use importlib due to circular import when: "from minari import __version__"
-__version__ = importlib.metadata.version('minari')
+__version__ = importlib.metadata.version("minari")
 
-def _check_datasets_to_combine(datasets: List[MinariDataset]):
-    # Check the env_spec
-    # Check the minari version
-    datasets_minari_version = []
+
+# def _check_datasets_to_combine(datasets: List[MinariDataset]):
+#     # Check the env_spec
+#     # Check the minari version
+#     datasets_minari_version = []
+
 
 class RandomPolicy:
     """A random action selection policy to compute `ref_min_score`."""

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -460,9 +460,7 @@ def create_dataset_from_buffers(
                 ), "Each episode must be terminated or truncated before adding it to a Minari dataset"
                 assert len(eps_buff["actions"]) + 1 == len(
                     eps_buff["observations"]
-                ), f"Number of observations {len(eps_buff['observations'])} must have an additional \
-                                                                                        element compared to the number of action steps {len(eps_buff['actions'])} \
-                                                                                        The initial and final observation must be included"
+                ), f"Number of observations {len(eps_buff['observations'])} must have an additional element compared to the number of action steps {len(eps_buff['actions'])}. The initial and final observation must be included"
                 seed = eps_buff.pop("seed", None)
                 eps_group = clear_episode_buffer(
                     eps_buff, file.create_group(f"episode_{i}")
@@ -511,7 +509,7 @@ def create_dataset_from_buffers(
                 file.attrs["ref_min_score"] = ref_min_score
                 file.attrs["num_episodes_average_score"] = num_episodes_average_score
 
-            file["minari_version"] = minari_version
+            file.attrs["minari_version"] = minari_version
 
         return MinariDataset(data_path)
     else:

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -37,8 +37,14 @@ def combine_minari_version_specifiers(specifier_set: SpecifierSet):
     The supported version specifier operators are those in PEP 440(https://peps.python.org/pep-0440/#version-specifiers), 
     except for '==='.
 
+    Args:
+        specifier_set (SpecifierSet): set of all version specifiers to intersect
+
+    Returns:
+        version_specifier (SpecifierSet): resulting version specifier
+
     """
-    specifiers = sorted(specifiers, key=str)
+    specifiers = sorted(specifier_set, key=str)
 
     exclusion_specifiers = filter(lambda spec: spec.operator == '!=', specifiers)
     inclusion_specifiers = filter(lambda spec: spec.operator != '!=', specifiers)
@@ -80,6 +86,7 @@ def combine_minari_version_specifiers(specifier_set: SpecifierSet):
     final_version_specifier = SpecifierSet()
 
     if inclusion_interval.lower == inclusion_interval.upper:
+        assert inclusion_interval.lower == __version__
         final_version_specifier &= f'=={inclusion_interval.lower}'
         # There is just one compatible version of Minari
         return final_version_specifier

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -20,8 +20,13 @@ from minari.storage.datasets_root_dir import get_dataset_path
 
 import importlib.metadata
 
-MINARI_VERSION = importlib.metadata.version('minari')
+# Use importlib due to circular import when: "from minari import __version__"
+__version__ = importlib.metadata.version('minari')
 
+def _check_datasets_to_combine(datasets: List[MinariDataset]):
+    # Check the env_spec
+    # Check the minari version
+    datasets_minari_version = []
 
 class RandomPolicy:
     """A random action selection policy to compute `ref_min_score`."""
@@ -457,7 +462,7 @@ def create_dataset_from_collector_env(
                 "author": str(author),
                 "author_email": str(author_email),
                 "code_permalink": str(code_permalink),
-                "minari_version": MINARI_VERSION,
+                "minari_version": __version__,
             },
         )
         return MinariDataset(data_path)

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -27,7 +27,7 @@ from minari.storage.datasets_root_dir import get_dataset_path
 __version__ = importlib.metadata.version("minari")
 
 def combine_minari_version_specifiers(specifier_set: SpecifierSet):
-    """ Calculates the Minari version specifier dependency intersection between a group of Minari version specifiers.
+    """Calculates the Minari version specifier by intersecting a group of Minari version specifiers.
 
     Used to calculate the `minari_version` metadata attribute when combining multiple datasets. The function
     assumes that all the given version specifiers at least contain the current minari version thus the version

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -18,6 +18,10 @@ from minari.dataset.minari_storage import clear_episode_buffer
 from minari.serialization import serialize_space
 from minari.storage.datasets_root_dir import get_dataset_path
 
+import importlib.metadata
+
+MINARI_VERSION = importlib.metadata.version('minari')
+
 
 class RandomPolicy:
     """A random action selection policy to compute `ref_min_score`."""
@@ -47,6 +51,7 @@ def combine_datasets(
     """
     new_dataset_path = get_dataset_path(new_dataset_id)
 
+    # TODO: Make sure that the datasets support the same Minari versions
     # Check if dataset already exists
     if not os.path.exists(new_dataset_path):
         new_dataset_path = os.path.join(new_dataset_path, "data")
@@ -343,6 +348,8 @@ def create_dataset_from_buffers(
                 file.attrs["ref_max_score"] = ref_max_score
                 file.attrs["ref_min_score"] = ref_min_score
                 file.attrs["num_episodes_average_score"] = num_episodes_average_score
+            
+            file["minari_version"] = MINARI_VERSION
 
         return MinariDataset(data_path)
     else:
@@ -444,7 +451,14 @@ def create_dataset_from_collector_env(
 
         collector_env.save_to_disk(
             data_path,
-            dataset_metadata=dataset_metadata,
+            dataset_metadata={
+                "dataset_id": str(dataset_id),
+                "algorithm_name": str(algorithm_name),
+                "author": str(author),
+                "author_email": str(author_email),
+                "code_permalink": str(code_permalink),
+                "minari_version": MINARI_VERSION,
+            },
         )
         return MinariDataset(data_path)
     else:

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -431,19 +431,21 @@ def create_dataset_from_buffers(
             UserWarning,
         )
     if minari_version is None:
+        version = Version(__version__)
+        release = version.release
+        # For __version__ = X.Y.Z, set version specifier by default to compatibility with version X.Y or later, but not (X+1).0 or later.
+        minari_version = f"~={'.'.join(str(x) for x in release[:2])}"
         warnings.warn(
-            f"`minari_version` is set to None. The compatible dataset version specifier for Minari will be automatically fixed to the installed version {__version__}.",
+            f"`minari_version` is set to None. The compatible dataset version specifier for Minari will be set to {minari_version}.",
             UserWarning,
         )
-        minari_version = f"=={__version__}"
-    else:
-        # Check if the installed Minari version falls inside the minari_version specifier
-        try:
-            assert Version(__version__) in Specifier(
-                minari_version
-            ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
-        except InvalidSpecifier:
-            print(f"{minari_version} is not a version specifier.")
+    # Check if the installed Minari version falls inside the minari_version specifier
+    try:
+        assert Version(__version__) in Specifier(
+            minari_version
+        ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
+    except InvalidSpecifier:
+        print(f"{minari_version} is not a version specifier.")
 
     if observation_space is None:
         observation_space = env.observation_space
@@ -590,19 +592,21 @@ def create_dataset_from_collector_env(
             "Can't pass a value for `expert_policy` and `ref_max_score` at the same time."
         )
     if minari_version is None:
+        version = Version(__version__)
+        release = version.release
+        # For __version__ = X.Y.Z, by default compatibility with version X.Y or later, but not (X+1).0 or later.
+        minari_version = f"~={'.'.join(str(x) for x in release[:2])}"
         warnings.warn(
-            f"`minari_version` is set to None. The compatible dataset version specifier for Minari will be automatically fixed to the installed version {__version__}.",
+            f"`minari_version` is set to None. The compatible dataset version specifier for Minari will be set to {minari_version}.",
             UserWarning,
         )
-        minari_version = f"=={__version__}"
-    else:
-        # Check if the installed Minari version falls inside the minari_version specifier
-        try:
-            assert Version(__version__) in Specifier(
-                minari_version
-            ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
-        except InvalidSpecifier:
-            print(f"{minari_version} is not a version specifier.")
+    # Check if the installed Minari version falls inside the minari_version specifier
+    try:
+        assert Version(__version__) in Specifier(
+            minari_version
+        ), f"The installed Minari version {__version__} is not contained in the dataset version specifier {minari_version}."
+    except InvalidSpecifier:
+        print(f"{minari_version} is not a version specifier.")
 
     assert collector_env.datasets_path is not None
     dataset_path = os.path.join(collector_env.datasets_path, dataset_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "minari"
 description = "A standard format for offline reinforcement learning datasets, with popular reference datasets and related utilities."
 readme = "README.md"
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "Offline RL", "RL", "AI", "gymnasium", "Farama"]
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 4 - Beta",  # change to `5 - Production/Stable` when ready
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -79,7 +78,7 @@ exclude = ["**/node_modules", "**/__pycache__"]
 strict = []
 
 typeCheckingMode = "basic"
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 typeshedPath = "typeshed"
 enableTypeIgnoreComments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "tqdm>=4.65.0",
     "typing_extensions==4.4.0",
     "google-cloud-storage==2.5.0",
-    "typer[all]==0.7.0",
+    "typer[all]==0.9.0",
     "gymnasium>=0.28.1",
     "portion==2.4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "google-cloud-storage==2.5.0",
     "typer[all]==0.7.0",
     "gymnasium>=0.28.1",
+    "portion==2.4.0",
 ]
 dynamic = ["version"]
 

--- a/tests/dataset/test_dataset_download.py
+++ b/tests/dataset/test_dataset_download.py
@@ -3,12 +3,29 @@ import pytest
 import minari
 from minari import MinariDataset
 from minari.storage.datasets_root_dir import get_dataset_path
+from minari.storage.hosting import get_remote_dataset_versions
 from tests.common import check_data_integrity
+
+
+env_names = ["pen", "door", "hammer", "relocate"]
+
+
+def get_latest_compatible_dataset_id(env_name, dataset_name):
+    latest_compatible_version = get_remote_dataset_versions(
+        dataset_name=dataset_name,
+        env_name=env_name,
+        latest_version=True,
+        compatible_minari_version=True,
+    )[0]
+    return f"{env_name}-{dataset_name}-v{latest_compatible_version}"
 
 
 @pytest.mark.parametrize(
     "dataset_id",
-    ["pen-human-v1", "door-human-v1", "hammer-human-v1", "relocate-human-v1"],
+    [
+        get_latest_compatible_dataset_id(env_name=env_name, dataset_name="human")
+        for env_name in env_names
+    ],
 )
 def test_download_dataset_from_farama_server(dataset_id: str):
     """Test downloading Minari datasets from remote server.

--- a/tests/dataset/test_dataset_download.py
+++ b/tests/dataset/test_dataset_download.py
@@ -8,7 +8,7 @@ from tests.common import check_data_integrity
 
 @pytest.mark.parametrize(
     "dataset_id",
-    ["pen-human-v0", "door-human-v0", "hammer-human-v0", "relocate-human-v0"],
+    ["pen-human-v1", "door-human-v1", "hammer-human-v1", "relocate-human-v1"],
 )
 def test_download_dataset_from_farama_server(dataset_id: str):
     """Test downloading Minari datasets from remote server.

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -24,7 +24,7 @@ def _create_dummy_dataset(file_path):
         f.attrs["total_episodes"] = 100
         f.attrs["total_steps"] = 1000
         f.attrs["dataset_id"] = "dummy-test-v0"
-        f.attrs["minari_version"] = __version__
+        f.attrs["minari_version"] = f"=={__version__}"
 
 
 def test_minari_storage_missing_env_module():

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -3,6 +3,7 @@ import os
 import h5py
 import pytest
 
+from minari import __version__
 from minari.dataset.minari_storage import MinariStorage
 
 
@@ -23,6 +24,7 @@ def _create_dummy_dataset(file_path):
         f.attrs["total_episodes"] = 100
         f.attrs["total_steps"] = 1000
         f.attrs["dataset_id"] = "dummy-test-v0"
+        f.attrs["minari_version"] = __version__
 
 
 def test_minari_storage_missing_env_module():

--- a/tests/utils/test_dataset_combine.py
+++ b/tests/utils/test_dataset_combine.py
@@ -1,9 +1,13 @@
+from typing import Optional
+
 import gymnasium as gym
+import pytest
 from gymnasium.utils.env_checker import data_equivalence
+from packaging.specifiers import SpecifierSet
 
 import minari
 from minari import DataCollectorV0, MinariDataset
-from minari.utils import combine_datasets
+from minari.utils import combine_datasets, combine_minari_version_specifiers
 
 
 def _check_env_recovery(gymnasium_environment: gym.Env, dataset: MinariDataset):
@@ -54,14 +58,23 @@ def _check_load_and_delete_dataset(dataset_id: str):
     assert dataset_id not in local_datasets
 
 
-def _generate_dataset_with_collector_env(dataset_id: str, num_episodes: int = 10):
+def _generate_dataset_with_collector_env(
+    dataset_id: str, num_episodes: int = 10, max_episode_steps: Optional[int] = 500
+):
     """Helper function to create tmp dataset to combining.
 
     Args:
         dataset_id (str): name of the generated Minari dataset
         num_episodes (int): number of episodes in the generated dataset
+        max_episode_steps (int | None): max episodes per step of the environment
     """
-    env = gym.make("CartPole-v1")
+    if max_episode_steps is None:
+        # Force None max_episode_steps
+        env_spec = gym.make("CartPole-v1").spec
+        env_spec.max_episode_steps = None
+        env = env_spec.make()
+    else:
+        env = gym.make("CartPole-v1", max_episode_steps=max_episode_steps)
 
     env = DataCollectorV0(env)
     # Step the environment, DataCollectorV0 wrapper will do the data collection job
@@ -138,3 +151,83 @@ def test_combine_datasets():
 
     # checking that we still can load combined dataset after deleting source datasets
     _check_load_and_delete_dataset("cartpole-combined-test-v0")
+
+    # testing re-calculation of env_spec.max_episode_steps: max(max_episode_steps) or None propagates.
+    dataset_max_episode_steps = [5, 10, None]
+    test_datasets_ids = [
+        f"cartpole-test-{i}-v0" for i in range(len(dataset_max_episode_steps))
+    ]
+
+    local_datasets = minari.list_local_datasets()
+    # generating multiple test datasets
+    for dataset_id, max_episode_steps in zip(
+        test_datasets_ids, dataset_max_episode_steps
+    ):
+        if dataset_id in local_datasets:
+            minari.delete_dataset(dataset_id)
+        _generate_dataset_with_collector_env(
+            dataset_id, num_episodes, max_episode_steps
+        )
+
+    test_datasets = [
+        minari.load_dataset(dataset_id) for dataset_id in test_datasets_ids
+    ]
+
+    # testing without creating a copy
+    combined_dataset = combine_datasets(
+        test_datasets, new_dataset_id="cartpole-combined-test-v0"
+    )
+    assert combined_dataset.spec.env_spec.max_episode_steps is None
+    _check_load_and_delete_dataset("cartpole-combined-test-v0")
+
+    # testing with copy
+    combined_dataset = combine_datasets(
+        test_datasets, new_dataset_id="cartpole-combined-test-v0", copy=True
+    )
+    assert combined_dataset.spec.env_spec.max_episode_steps is None
+    _check_load_and_delete_dataset("cartpole-combined-test-v0")
+
+    # Check that we get max(max_episode_steps) when there is no max_episode_steps=None
+    test_datasets.pop()
+    # testing without creating a copy
+    combined_dataset = combine_datasets(
+        test_datasets, new_dataset_id="cartpole-combined-test-v0"
+    )
+    assert combined_dataset.spec.env_spec.max_episode_steps == 10
+    _check_load_and_delete_dataset("cartpole-combined-test-v0")
+
+    # testing with copy
+    combined_dataset = combine_datasets(
+        test_datasets, new_dataset_id="cartpole-combined-test-v0", copy=True
+    )
+    assert combined_dataset.spec.env_spec.max_episode_steps == 10
+    _check_load_and_delete_dataset("cartpole-combined-test-v0")
+
+    # deleting test datasets
+    for dataset_id in test_datasets_ids:
+        minari.delete_dataset(dataset_id)
+
+
+@pytest.mark.parametrize(
+    "specifier_intersection,version_specifiers",
+    [
+        (
+            SpecifierSet(">3.0.0, <=3.9.1"),
+            SpecifierSet(">3.0.0") & SpecifierSet("<=3.9.1"),
+        ),
+        (
+            SpecifierSet(">3.2, <=3.2.5"),
+            SpecifierSet(">=3.0.0, <3.3.0") & SpecifierSet(">3.2, <=3.2.5"),
+        ),
+        (SpecifierSet(">=1.3.0, !=1.4.0"), SpecifierSet(">=1.3.0, !=1.4.0")),
+        (SpecifierSet(">=1.3.0"), SpecifierSet(">=1.3.0, !=1.2.0")),
+        (
+            SpecifierSet(">=3.0.0, <=3.9.1"),
+            SpecifierSet("~=3.0") & SpecifierSet("<=3.9.1"),
+        ),
+    ],
+)
+def test_combine_minari_version_specifiers(specifier_intersection, version_specifiers):
+    intersection = combine_minari_version_specifiers(version_specifiers)
+
+    assert specifier_intersection == intersection


### PR DESCRIPTION
# Description

This PR adds the `minari_version` attribute to each dataset. This attribute is a version specifier which should contain the Minari versions that the dataset is compatible with (follows [PEP 440](https://peps.python.org/pep-0440/#version-specifiers)). When combining datasets `minari/utils.py::combine_minari_version_specifiers()` will calculate the intersection between all version specifiers for the resulting dataset. If there is no intersection, the datasets don't have any common minari dependency and can't be combined. The version specifier intersection adds a new dependency `portion` to create the version specifier intervals.

`minari_version` is specified when creating a dataset with `create_dataset_from_buffers` or `create_dataset_from_collector_env`. If not given a value, `minari_version` is initialized to `"=={version}"` where `version` is the local installed minari version.

This PR also contains some CLI updates:
- Bump `typer==0.9.0` and add `Annotated` to arguments and options as recommended by Typer docs.
- For the commands `minari list remote/local` only the compatible datasets with the local installed minari version and the latest version of each dataset will appear in the table. To show all dataset versions `--all` or `-a` can be used. Also the dataset names in the table are alphabetically ordered.
- Add `--force` option to `minari download dataset_id`.

Finally, used this PR to also remove Python 3.7 compatibility due to EOL. This has already been done for [Gymnasium](https://github.com/Farama-Foundation/Gymnasium/pull/573)


The PR is missing test which I'll add shortly. Current tests for downloading datasets are failing because the remote datasets need to be updated with the new attribute. I can proceed to update the remote datasets once the changes are approved.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
