### PR TITLE
Update docs with EpisodeData info

### DIFF
--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -540,3 +540,29 @@ The Minari storage format supports the following observation and action spaces:
 
 #### Space Serialization
 Spaces are serialized to a JSON format when saving to disk. This serialization supports all space types supported by Minari, and aims to be both human, and machine readable. The serialized action and observation spaces for the episodes in the dataset are saved as strings in the global HDF5 group metadata in `main_data.hdf5` for a particular dataset as `action_space` and `observation_space` respectively. All episodes in `main_data.hdf5` must have observations and actions that comply with these action and observation spaces. 
+
+## Minari Data Structures
+
+A Minari dataset is encapsulated in the `MinariDataset` class which allows for iterating and sampling through episodes which are defined as `EpisodeData` data class.
+
+### EpisodeData Structure
+
+Episodes can be accessed from a Minari dataset through iteration, random sampling, or even filtering episodes from a dataset through an arbitrary condition via the `filter_episodes` method. Take the following example where we load the `door-human-v0` dataset and randomly sample 10 episodes:
+
+```python
+dataset = minari.load_dataset("door-human-v0")
+sampled_episodes = dataset.sample_episodes(10)
+```
+
+The `sampled_episodes` variable will be a list of 10 `EpisodeData` elements, each containing episode data. An `EpisodeData` element is a data class consisting of the following fields:
+
+| Field             | Type         | Description                                                   |
+| ----------------- | ------------ | ------------------------------------------------------------- |
+| `id`              | `np.int64`   | ID of the episode.                                            |
+| `seed`            | `np.int64`   | Seed used to reset the episode.                               |
+| `total_timesteps` | `np.int64`   | Number of timesteps in the episode.                           |
+| `observations`    | `np.ndarray` | Observations for each timestep including initial observation. |
+| `actions`         | `np.ndarray` | Actions for each timestep.                                    |
+| `rewards`         | `np.ndarray` | Rewards for each timestep.                                    |
+| `terminations`    | `np.ndarray` | Terminations for each timestep.                               |
+| `truncations`     | `np.ndarray` | Truncations for each timestep.                                |

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -561,8 +561,8 @@ The `sampled_episodes` variable will be a list of 10 `EpisodeData` elements, eac
 | `id`              | `np.int64`                           | ID of the episode.                                            |
 | `seed`            | `np.int64`                           | Seed used to reset the episode.                               |
 | `total_timesteps` | `np.int64`                           | Number of timesteps in the episode.                           |
-| `observations`    | `np.ndarray`, `str`, `tuple`, `dict` | Observations for each timestep including initial observation. |
-| `actions`         | `np.ndarray`, `str`, `tuple`, `dict` | Actions for each timestep.                                    |
+| `observations`    | `np.ndarray`, `list`, `tuple`, `dict` | Observations for each timestep including initial observation. |
+| `actions`         | `np.ndarray`, `list`, `tuple`, `dict` | Actions for each timestep.                                    |
 | `rewards`         | `np.ndarray`                         | Rewards for each timestep.                                    |
 | `terminations`    | `np.ndarray`                         | Terminations for each timestep.                               |
 | `truncations`     | `np.ndarray`                         | Truncations for each timestep.                                |

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -556,13 +556,15 @@ sampled_episodes = dataset.sample_episodes(10)
 
 The `sampled_episodes` variable will be a list of 10 `EpisodeData` elements, each containing episode data. An `EpisodeData` element is a data class consisting of the following fields:
 
-| Field             | Type         | Description                                                   |
-| ----------------- | ------------ | ------------------------------------------------------------- |
-| `id`              | `np.int64`   | ID of the episode.                                            |
-| `seed`            | `np.int64`   | Seed used to reset the episode.                               |
-| `total_timesteps` | `np.int64`   | Number of timesteps in the episode.                           |
-| `observations`    | `np.ndarray` | Observations for each timestep including initial observation. |
-| `actions`         | `np.ndarray` | Actions for each timestep.                                    |
-| `rewards`         | `np.ndarray` | Rewards for each timestep.                                    |
-| `terminations`    | `np.ndarray` | Terminations for each timestep.                               |
-| `truncations`     | `np.ndarray` | Truncations for each timestep.                                |
+| Field             | Type                                 | Description                                                   |
+| ----------------- | ------------------------------------ | ------------------------------------------------------------- |
+| `id`              | `np.int64`                           | ID of the episode.                                            |
+| `seed`            | `np.int64`                           | Seed used to reset the episode.                               |
+| `total_timesteps` | `np.int64`                           | Number of timesteps in the episode.                           |
+| `observations`    | `np.ndarray`, `str`, `tuple`, `dict` | Observations for each timestep including initial observation. |
+| `actions`         | `np.ndarray`, `str`, `tuple`, `dict` | Actions for each timestep.                                    |
+| `rewards`         | `np.ndarray`                         | Rewards for each timestep.                                    |
+| `terminations`    | `np.ndarray`                         | Terminations for each timestep.                               |
+| `truncations`     | `np.ndarray`                         | Truncations for each timestep.                                |
+
+As mentioned in the `Supported Spaces` section, many different observation and action spaces are supported so the data type for these fields are dependent on the environment being used.


### PR DESCRIPTION
# Description

This PR adds a section to the `Dataset Standards` documentation page describing the `EpisodeData` data structure and the fields it contains. Also includes a small snippet of sampling episodes from a Minari dataset.

## Type of change

- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
