### PR TITLE
Get normalized scores

### DIFF
--- a/docs/api/minari_functions.md
+++ b/docs/api/minari_functions.md
@@ -50,3 +50,9 @@ minari_dataset/episode_data
 ```{eval-rst}
 .. autofunction:: minari.combine_datasets
 ```
+
+## Normalize Score
+
+```{eval-rst}
+.. autofunction:: minari.get_normalized_score
+```

--- a/minari/__init__.py
+++ b/minari/__init__.py
@@ -11,6 +11,7 @@ from minari.utils import (
     combine_datasets,
     create_dataset_from_buffers,
     create_dataset_from_collector_env,
+    get_normalized_score,
     split_dataset,
 )
 
@@ -34,6 +35,7 @@ __all__ = [
     "create_dataset_from_buffers",
     "create_dataset_from_collector_env",
     "split_dataset",
+    "get_normalized_score",
 ]
 
 __version__ = "0.3.1"

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -447,7 +447,9 @@ class DataCollectorV0(gym.Wrapper):
         # Clear in-memory buffers
         self._buffer.clear()
 
-    def save_to_disk(self, path: str, dataset_metadata: Optional[Dict] = None):
+    def save_to_disk(
+        self, path: str, dataset_metadata: Optional[Dict[str, Any]] = None
+    ):
         """Save all in-memory buffer data and move temporary HDF5 file to a permanent location in disk.
 
         Args:

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -176,7 +176,7 @@ class DataCollectorV0(gym.Wrapper):
                     assert isinstance(
                         episode_buffer[key], dict
                     ), f"Element to be inserted is type 'dict', but buffer accepts type {type(episode_buffer[key])}"
-                    
+
                     episode_buffer[key] = self._add_to_episode_buffer(
                         episode_buffer[key], value
                     )
@@ -231,7 +231,9 @@ class DataCollectorV0(gym.Wrapper):
         # certain conditions.
         if self._new_episode and not self._reset_called:
             if isinstance(self._previous_eps_final_obs, dict):
-                self._buffer[-1]["observations"] = self._add_to_episode_buffer({}, self._previous_eps_final_obs)
+                self._buffer[-1]["observations"] = self._add_to_episode_buffer(
+                    {}, self._previous_eps_final_obs
+                )
             else:
                 self._buffer[-1]["observations"] = [self._previous_eps_final_obs]
             if self._record_infos:

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -176,6 +176,7 @@ class DataCollectorV0(gym.Wrapper):
                     assert isinstance(
                         episode_buffer[key], dict
                     ), f"Element to be inserted is type 'dict', but buffer accepts type {type(episode_buffer[key])}"
+                    
                     episode_buffer[key] = self._add_to_episode_buffer(
                         episode_buffer[key], value
                     )
@@ -203,7 +204,6 @@ class DataCollectorV0(gym.Wrapper):
             terminated=terminated,
             truncated=truncated,
         )
-
         # Force step data dictionary to include keys corresponding to Gymnasium step returns:
         # actions, observations, rewards, terminations, truncations, and infos
         assert STEP_DATA_KEYS.issubset(
@@ -230,7 +230,10 @@ class DataCollectorV0(gym.Wrapper):
         # or truncation. This may happen if the step_data_callback truncates or terminates the episode under
         # certain conditions.
         if self._new_episode and not self._reset_called:
-            self._buffer[-1]["observations"] = [self._previous_eps_final_obs]
+            if isinstance(self._previous_eps_final_obs, dict):
+                self._buffer[-1]["observations"] = self._add_to_episode_buffer({}, self._previous_eps_final_obs)
+            else:
+                self._buffer[-1]["observations"] = [self._previous_eps_final_obs]
             if self._record_infos:
                 self._buffer[-1]["infos"] = self._add_to_episode_buffer(
                     {}, self._previous_eps_final_info

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -181,7 +181,7 @@ class MinariDataset:
         """Indices of the available episodes to sample within the Minari dataset."""
         return self._episode_indices
 
-    def recover_environment(self):
+    def recover_environment(self) -> gym.Env:
         """Recover the Gymnasium environment used to create the dataset.
 
         Returns:

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -20,8 +20,8 @@ from minari.storage.datasets_root_dir import get_dataset_path
 
 
 class RandomPolicy:
-    """A random action selection policy to compute `ref_min_score`.
-    """
+    """A random action selection policy to compute `ref_min_score`."""
+
     def __init__(self, env: gym.Env):
         self.action_space = env.action_space
         self.action_space.seed(123)
@@ -271,7 +271,9 @@ def create_dataset_from_buffers(
         action_space = env.action_space
 
     if expert_policy is not None and ref_max_score is not None:
-        raise ValueError("Can't pass a value for `expert_policy` and `ref_max_score` at the same time.")
+        raise ValueError(
+            "Can't pass a value for `expert_policy` and `ref_max_score` at the same time."
+        )
 
     dataset_path = get_dataset_path(dataset_id)
 
@@ -400,7 +402,9 @@ def create_dataset_from_collector_env(
             UserWarning,
         )
     if expert_policy is not None and ref_max_score is not None:
-        raise ValueError("Can't pass a value for `expert_policy` and `ref_max_score` at the same time.")
+        raise ValueError(
+            "Can't pass a value for `expert_policy` and `ref_max_score` at the same time."
+        )
 
     assert collector_env.datasets_path is not None
     dataset_path = os.path.join(collector_env.datasets_path, dataset_id)

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -239,7 +239,8 @@ def create_dataset_from_buffers(
         author (Optional[str], optional): author that generated the dataset. Defaults to None.
         author_email (Optional[str], optional): email of the author that generated the dataset. Defaults to None.
         code_permalink (Optional[str], optional): link to relevant code used to generate the dataset. Defaults to None.
-        ref_min_score( Optional[float], optional): minimum reference score from the average returns of a random policy. This value is later used to normalize a score with :meth:`minari.get_normalized_score`. If default None the value will be estimated with a default random policy.
+        ref_min_score (Optional[float], optional): minimum reference score from the average returns of a random policy. This value is later used to normalize a score with :meth:`minari.get_normalized_score`. If default None the value will be estimated with a default random policy.
+                                                    Also note that this attribute will be added to the Minari dataset only if `ref_max_score` or `expert_policy` are assigned a valid value other than None.
         ref_max_score (Optional[float], optional: maximum reference score from the average returns of a hypothetical expert policy. This value is used in `MinariDataset.get_normalized_score()`. Default None.
         expert_policy (Optional[Callable[[ObsType], ActType], optional): policy to compute `ref_max_score` by averaging the returns over a number of episodes equal to  `num_episodes_average_score`.
                                                                         `ref_max_score` and `expert_policy` can't be passed at the same time. Default to None

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -270,9 +270,8 @@ def create_dataset_from_buffers(
     if action_space is None:
         action_space = env.action_space
 
-    assert (
-        expert_policy is not None and ref_max_score is not None
-    ), "Can't pass a value for `expert_policy` and `ref_max_score` at the same time."
+    if expert_policy is not None and ref_max_score is not None:
+        raise ValueError("Can't pass a value for `expert_policy` and `ref_max_score` at the same time.")
 
     dataset_path = get_dataset_path(dataset_id)
 
@@ -400,9 +399,8 @@ def create_dataset_from_collector_env(
             "`author_email` is set to None. For longevity purposes it is highly recommended to provide an author email, or some other obvious contact information.",
             UserWarning,
         )
-    # assert (
-    #     expert_policy is not None and ref_max_score is not None
-    # ), "Can't pass a value for `expert_policy` and `ref_max_score` at the same time."
+    if expert_policy is not None and ref_max_score is not None:
+        raise ValueError("Can't pass a value for `expert_policy` and `ref_max_score` at the same time.")
 
     assert collector_env.datasets_path is not None
     dataset_path = os.path.join(collector_env.datasets_path, dataset_id)

--- a/tests/common.py
+++ b/tests/common.py
@@ -57,7 +57,7 @@ class DummyMultiDimensionalBoxEnv(gym.Env):
         return self.observation_space.sample(), {}
 
 
-class DummyTupleDisceteBoxEnv(gym.Env):
+class DummyTupleDiscreteBoxEnv(gym.Env):
     def __init__(self):
         self.action_space = spaces.Tuple(
             (
@@ -235,8 +235,8 @@ def register_dummy_envs():
     )
 
     register(
-        id="DummyTupleDisceteBoxEnv-v0",
-        entry_point="tests.common:DummyTupleDisceteBoxEnv",
+        id="DummyTupleDiscreteBoxEnv-v0",
+        entry_point="tests.common:DummyTupleDiscreteBoxEnv",
         max_episode_steps=5,
     )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -584,7 +584,7 @@ def check_episode_data_integrity(
     observation_space: gym.spaces.Space,
     action_space: gym.spaces.Space,
 ):
-    """Checks to see if a list of EpisodeData insteances has consistent data and that the observations and actions are in the appropriate spaces.
+    """Checks to see if a list of EpisodeData instances has consistent data and that the observations and actions are in the appropriate spaces.
 
     Args:
         episode_data_list (List[EpisodeData]): A list of EpisodeData instances representing episodes.

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+# Step, a known end of episode, check that the previous episode is truncated and that the next episode starts with the last obs, and info.
+
+
+
+def test_truncation_without_reset():
+
+
+

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -1,11 +1,145 @@
+import gymnasium as gym
+import numpy as np
 import pytest
 
-
-# Step, a known end of episode, check that the previous episode is truncated and that the next episode starts with the last obs, and info.
-
-
-
-def test_truncation_without_reset():
+import minari
+from minari import DataCollectorV0, EpisodeData, MinariDataset, StepDataCallback
+from tests.common import check_load_and_delete_dataset, register_dummy_envs
 
 
+register_dummy_envs()
 
+
+class ForceTruncateStepDataCallback(StepDataCallback):
+    episode_steps = 10
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.time_steps = 0
+
+    def __call__(self, env, **kwargs):
+        step_data = super().__call__(env, **kwargs)
+
+        step_data["terminations"] = False
+        if self.time_steps % self.episode_steps == 0:
+            step_data["truncations"] = True
+
+        self.time_steps += 1
+        return step_data
+
+
+def _get_step_from_dictionary_space(episode_data, step_index):
+    step_data = {}
+    assert isinstance(episode_data, dict)
+    for key, value in episode_data.items():
+        if isinstance(value, dict):
+            step_data[key] = _get_step_from_dictionary_space(value, step_index)
+        elif isinstance(value, tuple):
+            step_data[key] = _get_step_from_tuple_space(value, step_index)
+        else:
+            step_data[key] = value[step_index]
+    return step_data
+
+
+def _get_step_from_tuple_space(episode_data, step_index):
+    step_data = []
+    assert isinstance(episode_data, tuple)
+    for element in episode_data:
+        if isinstance(element, dict):
+            step_data.append(_get_step_from_dictionary_space(element, step_index))
+        elif isinstance(element, tuple):
+            step_data.append(_get_step_from_tuple_space(element, step_index))
+        else:
+            step_data.append(element[step_index])
+
+    return tuple(step_data)
+
+
+def get_single_step_from_episode(episode: EpisodeData, index: int) -> EpisodeData:
+    """Get a single step EpisodeData from a full episode."""
+    if isinstance(episode.observations, dict):
+        observation = _get_step_from_dictionary_space(episode.observations, index)
+    elif isinstance(episode.observations, tuple):
+        observation = _get_step_from_tuple_space(episode.observations, index)
+    else:
+        observation = episode.observations[index]
+    if isinstance(episode.actions, dict):
+        action = _get_step_from_dictionary_space(episode.actions, index)
+    elif isinstance(episode.actions, tuple):
+        action = _get_step_from_tuple_space(episode.actions, index)
+    else:
+        action = episode.actions[index]
+
+    step_data = {
+        "id": episode.id,
+        "total_timesteps": 1,
+        "seed": None,
+        "observations": observation,
+        "actions": action,
+        "rewards": episode.rewards[index],
+        "terminations": episode.terminations[index],
+        "truncations": episode.truncations[index],
+    }
+
+    return EpisodeData(**step_data)
+
+
+@pytest.mark.parametrize(
+    "dataset_id,env_id",
+    [
+        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
+        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
+        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
+        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
+    ],
+)
+def test_truncation_without_reset(dataset_id, env_id):
+    """Test new episode creation when environment is truncated and env.reset is not called."""
+    num_steps = 50
+    num_episodes = int(num_steps / ForceTruncateStepDataCallback.episode_steps)
+    env = gym.make(env_id, max_episode_steps=50)
+    env = DataCollectorV0(
+        env,
+        step_data_callback=ForceTruncateStepDataCallback,
+    )
+
+    env.reset()
+
+    for _ in range(num_steps):
+        env.step(env.action_space.sample())
+
+    dataset = minari.create_dataset_from_collector_env(
+        dataset_id=dataset_id,
+        collector_env=env,
+        algorithm_name="random_policy",
+        author="Farama",
+        author_email="farama@farama.org",
+    )
+
+    env.close()
+
+    assert isinstance(dataset, MinariDataset)
+    assert dataset.total_episodes == num_episodes
+    assert dataset.spec.total_episodes == num_episodes
+    assert len(dataset.episode_indices) == num_episodes
+
+    episodes_generator = dataset.iterate_episodes()
+    last_step = None
+    for episode in episodes_generator:
+        assert episode.total_timesteps == ForceTruncateStepDataCallback.episode_steps
+        assert episode.truncations[-1] is True
+        if last_step is not None:
+            first_step = get_single_step_from_episode(episode, 0)
+            # Check that the last observation of the previous episode is carried over to the next episode
+            # as the reset observation.
+            if isinstance(first_step.observations, dict) or isinstance(
+                first_step.observations, tuple
+            ):
+                assert first_step.observations == last_step.observations
+            else:
+                assert np.array_equal(first_step.observations, last_step.observations)
+        last_step = get_single_step_from_episode(episode, -1)
+
+    # check load and delete local dataset
+    check_load_and_delete_dataset(dataset_id)

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -128,7 +128,6 @@ def test_truncation_without_reset(dataset_id, env_id):
     last_step = None
     for episode in episodes_generator:
         assert episode.total_timesteps == ForceTruncateStepDataCallback.episode_steps
-        assert episode.truncations[-1] is True
         if last_step is not None:
             first_step = get_single_step_from_episode(episode, 0)
             # Check that the last observation of the previous episode is carried over to the next episode
@@ -140,6 +139,8 @@ def test_truncation_without_reset(dataset_id, env_id):
             else:
                 assert np.array_equal(first_step.observations, last_step.observations)
         last_step = get_single_step_from_episode(episode, -1)
+        print(last_step.truncations)
+        assert bool(last_step.truncations) is True
 
     # check load and delete local dataset
     check_load_and_delete_dataset(dataset_id)

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -63,7 +63,7 @@ def test_episode_data(space: gym.Space):
         ("dummy-box-test-v0", "DummyBoxEnv-v0"),
         ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
         ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDisceteBoxEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
     ],
 )
 def test_update_dataset_from_collector_env(dataset_id, env_id):
@@ -119,7 +119,7 @@ def test_update_dataset_from_collector_env(dataset_id, env_id):
         ("dummy-box-test-v0", "DummyBoxEnv-v0"),
         ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
         ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDisceteBoxEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
     ],
 )
 def test_filter_episodes_and_subsequent_updates(dataset_id, env_id):
@@ -301,7 +301,7 @@ def test_filter_episodes_and_subsequent_updates(dataset_id, env_id):
         ("dummy-box-test-v0", "DummyBoxEnv-v0"),
         ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
         ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDisceteBoxEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
     ],
 )
 def test_sample_episodes(dataset_id, env_id):
@@ -344,7 +344,7 @@ def test_sample_episodes(dataset_id, env_id):
         ("dummy-box-test-v0", "DummyBoxEnv-v0"),
         ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
         ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDisceteBoxEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
     ],
 )
 def test_iterate_episodes(dataset_id, env_id):
@@ -393,7 +393,7 @@ def test_iterate_episodes(dataset_id, env_id):
         ("dummy-box-test-v0", "DummyBoxEnv-v0"),
         ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
         ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDisceteBoxEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
     ],
 )
 def test_update_dataset_from_buffer(dataset_id, env_id):

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -30,7 +30,7 @@ register_dummy_envs()
         ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
         ("dummy-text-test-v0", "DummyTextEnv-v0"),
         ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDisceteBoxEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
     ],
 )
 def test_generate_dataset_with_collector_env(dataset_id, env_id):
@@ -95,7 +95,7 @@ def test_generate_dataset_with_collector_env(dataset_id, env_id):
         ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
         ("dummy-text-test-v0", "DummyTextEnv-v0"),
         ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDisceteBoxEnv-v0"),
+        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
     ],
 )
 def test_generate_dataset_with_external_buffer(dataset_id, env_id):


### PR DESCRIPTION
# Description

This PR adds the [`get_normalized_score()` function from D4RL](https://github.com/Farama-Foundation/D4RL/blob/71a9549f2091accff93eeff68f1f3ab2c0e0a288/d4rl/offline_env.py#L71) for policy testing and comparisson. This function is added as a utility instead of a method in every MinariDataset since we haven't decided if we want to keep this feature for all future datasets in Minari and not all offline RL tasks can by tested in this manner (due to complexity of generating an expert policy for a reference maximum score).

This function requires the dataset to have two attributes which can be set when creating the dataset, `ref_min_score` and `ref_max_score`. These attributes are optional and if not present in the dataset `get_normalized_socre()` will through an error.
To set these attributes they can be directly passed by the user when creating the dataset, or by passing a callable expert policy to obtain the episode returns from. Note that if `ref_min_score` is not passed, it will be internally computed with a random policy.

I'm using this PR to also fix an issue with storing dictionary observation spaces in the DataCollectorV0 and not resetting the environment when `terminated` or `truncated`. I added a comment in the specific line changes.

This PR is a Draft because I need to update the PointMaze dataset generation tutorial to include the reference scores. There are some issues and differences with the D4RL PointMaze reference scores that I'll list here.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
