### PR TITLE
[Bug Fix] Fix h5py group creation

### DIFF
--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -327,15 +327,6 @@ class DataCollectorV0(gym.Wrapper):
         self._reset_called = True
 
         return obs, info
-    
-    def _get_h5py_subgroup(self, group: h5py.Group, name: str) -> h5py.Group:
-        if name in group:
-            subgroup = group.get(name)
-            assert isinstance(subgroup, h5py.Group)
-        else:
-            subgroup = group.create_group(name)
-        
-        return subgroup
 
     def clear_buffer_to_tmp_file(self, truncate_last_episode: bool = False):
         """Save the global buffer in-memory to a temporary HDF5 file in disk.
@@ -343,6 +334,7 @@ class DataCollectorV0(gym.Wrapper):
         Args:
             truncate_last_episode (bool, optional): If True the last episode from the buffer will be truncated before saving to disk. Defaults to False.
         """
+
         def get_h5py_subgroup(group: h5py.Group, name: str) -> h5py.Group:
             """Get a subgroup from an h5py group.
 
@@ -351,7 +343,7 @@ class DataCollectorV0(gym.Wrapper):
             Args:
                 group (h5py.Group): the h5py group object to look for/create the subgroup.
                 name (str): name of the subgroup.
-            
+
             Returns:
                 subgroup (h5py.Group)
             """
@@ -360,7 +352,7 @@ class DataCollectorV0(gym.Wrapper):
                 assert isinstance(subgroup, h5py.Group)
             else:
                 subgroup = group.create_group(name)
-            
+
             return subgroup
 
         def clear_buffer(dictionary_buffer: EpisodeBuffer, episode_group: h5py.Group):

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -327,6 +327,15 @@ class DataCollectorV0(gym.Wrapper):
         self._reset_called = True
 
         return obs, info
+    
+    def _get_h5py_subgroup(self, group: h5py.Group, name: str) -> h5py.Group:
+        if name in group:
+            subgroup = group.get(name)
+            assert isinstance(subgroup, h5py.Group)
+        else:
+            subgroup = group.create_group(name)
+        
+        return subgroup
 
     def clear_buffer_to_tmp_file(self, truncate_last_episode: bool = False):
         """Save the global buffer in-memory to a temporary HDF5 file in disk.
@@ -334,6 +343,25 @@ class DataCollectorV0(gym.Wrapper):
         Args:
             truncate_last_episode (bool, optional): If True the last episode from the buffer will be truncated before saving to disk. Defaults to False.
         """
+        def get_h5py_subgroup(group: h5py.Group, name: str) -> h5py.Group:
+            """Get a subgroup from an h5py group.
+
+            If the subgroup does not exist, create and return and empty group with the given name.
+
+            Args:
+                group (h5py.Group): the h5py group object to look for/create the subgroup.
+                name (str): name of the subgroup.
+            
+            Returns:
+                subgroup (h5py.Group)
+            """
+            if name in group:
+                subgroup = group.get(name)
+                assert isinstance(subgroup, h5py.Group)
+            else:
+                subgroup = group.create_group(name)
+            
+            return subgroup
 
         def clear_buffer(dictionary_buffer: EpisodeBuffer, episode_group: h5py.Group):
             """Inner function to recursively save the nested data dictionaries in an episode buffer.
@@ -345,9 +373,7 @@ class DataCollectorV0(gym.Wrapper):
             """
             for key, data in dictionary_buffer.items():
                 if isinstance(data, dict):
-                    eps_group_to_clear = episode_group.get(
-                        key, episode_group.create_group(key)
-                    )
+                    eps_group_to_clear = get_h5py_subgroup(episode_group, key)
                     clear_buffer(data, eps_group_to_clear)
                 elif all(map(lambda elem: isinstance(elem, tuple), data)):
                     # we have a list of tuples, so we need to act appropriately
@@ -355,9 +381,7 @@ class DataCollectorV0(gym.Wrapper):
                         f"_index_{str(i)}": [entry[i] for entry in data]
                         for i, _ in enumerate(data[0])
                     }
-                    eps_group_to_clear = episode_group.get(
-                        key, episode_group.create_group(key)
-                    )
+                    eps_group_to_clear = get_h5py_subgroup(episode_group, key)
                     clear_buffer(dict_data, eps_group_to_clear)
                 elif all(map(lambda elem: isinstance(elem, OrderedDict), data)):
                     # we have a list of OrderedDicts, so we need to act appropriately
@@ -365,9 +389,7 @@ class DataCollectorV0(gym.Wrapper):
                         key: [entry[key] for entry in data]
                         for key, value in data[0].items()
                     }
-                    eps_group_to_clear = episode_group.get(
-                        key, episode_group.create_group(key)
-                    )
+                    eps_group_to_clear = get_h5py_subgroup(episode_group, key)
                     clear_buffer(dict_data, eps_group_to_clear)
                 else:
                     if all(map(lambda elem: isinstance(elem, str), data)):


### PR DESCRIPTION
# Description
While creating a dataset I got an error due to a simplification in this previous PR https://github.com/Farama-Foundation/Minari/pull/102 to create non-existing h5py groups. It appears that this code doesn't work as I thought. The following code is an example that we can't check for existing/non-existing groups and create the group as default with the `get` function in h5py:
```python
import h5py


with h5py.File('testing_file.hdf5', 'a') as f:

    f.create_group('new_group')

    group = f.get('new_group', default=f.create_group('new_group'))
```
The code will throw an error saying that the group already exists.

My proposed fix is a function to implement the previous functionality from the mentioned PR (https://github.com/Farama-Foundation/Minari/pull/102)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
