### PR TITLE
Fix build docs

### DIFF
--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -8,7 +8,7 @@ from google.cloud import storage  # pyright: ignore [reportGeneralTypeIssues]
 
 from minari import list_remote_datasets
 from minari.dataset.minari_dataset import parse_dataset_id
-from minari.storage.hosting import find_highest_remote_version
+from minari.storage.hosting import get_remote_dataset_versions
 
 
 filtered_datasets = defaultdict(defaultdict)
@@ -19,7 +19,7 @@ for dataset_id in all_remote_datasets.keys():
     env_name, dataset_name, version = parse_dataset_id(dataset_id)
 
     if dataset_name not in filtered_datasets[env_name]:
-        max_version = find_highest_remote_version(env_name, dataset_name)
+        max_version = get_remote_dataset_versions(env_name, dataset_name, True)[0]
         max_version_dataset_id = "-".join([env_name, dataset_name, f"v{max_version}"])
         filtered_datasets[env_name][dataset_name] = all_remote_datasets[
             max_version_dataset_id


### PR DESCRIPTION
# Description

Use function `get_remote_dataset_versions()` instead of `find_highest_remote_version()` to generate the dataset doc scripts.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
