### PR TITLE
Add dataset spaces to docs

### DIFF
--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -44,8 +44,10 @@ for env_name, datasets in filtered_datasets.items():
         dataset_id = dataset_spec["dataset_id"]
         total_timesteps = dataset_spec["total_steps"]
         total_episodes = dataset_spec["total_episodes"]
-        dataset_action_space = dataset_spec["action_space"]
-        dataset_observation_space = dataset_spec["observation_space"]
+        dataset_action_space = dataset_spec["action_space"].__repr__().replace("\n", "")
+        dataset_observation_space = (
+            dataset_spec["observation_space"].__repr__().replace("\n", "")
+        )
         author = dataset_spec["author"]
         email = dataset_spec["author_email"]
         algo_name = dataset_spec["algorithm_name"]

--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -8,6 +8,7 @@ from google.cloud import storage  # pyright: ignore [reportGeneralTypeIssues]
 
 from minari import list_remote_datasets
 from minari.dataset.minari_dataset import parse_dataset_id
+from minari.serialization import deserialize_space
 from minari.storage.hosting import get_remote_dataset_versions
 
 
@@ -44,9 +45,13 @@ for env_name, datasets in filtered_datasets.items():
         dataset_id = dataset_spec["dataset_id"]
         total_timesteps = dataset_spec["total_steps"]
         total_episodes = dataset_spec["total_episodes"]
-        dataset_action_space = dataset_spec["action_space"].__repr__().replace("\n", "")
+        dataset_action_space = (
+            deserialize_space(dataset_spec["action_space"]).__repr__().replace("\n", "")
+        )
         dataset_observation_space = (
-            dataset_spec["observation_space"].__repr__().replace("\n", "")
+            deserialize_space(dataset_spec["observation_space"])
+            .__repr__()
+            .replace("\n", "")
         )
         author = dataset_spec["author"]
         email = dataset_spec["author_email"]

--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -44,6 +44,8 @@ for env_name, datasets in filtered_datasets.items():
         dataset_id = dataset_spec["dataset_id"]
         total_timesteps = dataset_spec["total_steps"]
         total_episodes = dataset_spec["total_episodes"]
+        dataset_action_space = dataset_spec["action_space"]
+        dataset_observation_space = dataset_spec["observation_space"]
         author = dataset_spec["author"]
         email = dataset_spec["author_email"]
         algo_name = dataset_spec["algorithm_name"]
@@ -97,6 +99,8 @@ title: {dataset_name.title()}
 |----|----|
 |Total Timesteps| `{total_timesteps}`|
 |Total Episodes | `{total_episodes}` |
+| Dataset Observation Space | `{dataset_observation_space}` |
+| Dataset Action Space | `{dataset_action_space}` |
 | Algorithm           | `{algo_name}`           |
 | Author              | `{author}`              |
 | Email               | `{email}`               |


### PR DESCRIPTION
# Description

This PR adds the serialized  attributes `observation_space` and `action_space` to the datasets documentation. We need to add this attributes because these two spaces can be different from the dataset's environment.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
