### PR TITLE
load dataset with download option

### DIFF
--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -7,6 +7,7 @@ import h5py
 from packaging.specifiers import SpecifierSet
 
 from minari.dataset.minari_dataset import MinariDataset, parse_dataset_id
+from minari.storage import hosting
 from minari.storage.datasets_root_dir import get_dataset_path
 
 
@@ -14,17 +15,27 @@ from minari.storage.datasets_root_dir import get_dataset_path
 __version__ = importlib.metadata.version("minari")
 
 
-def load_dataset(dataset_id: str):
+def load_dataset(dataset_id: str, download: bool = False):
     """Retrieve Minari dataset from local database.
 
     Args:
         dataset_id (str): name id of Minari dataset
+        download (bool): if `True` download the dataset if it is not found locally. Default to `False`.
 
     Returns:
         MinariDataset
     """
     file_path = get_dataset_path(dataset_id)
     data_path = os.path.join(file_path, "data", "main_data.hdf5")
+
+    if not os.path.exists(data_path):
+        if not download:
+            raise FileNotFoundError(
+                f"Dataset {dataset_id} not found locally at {file_path}. Use download=True to download the dataset."
+            )
+
+        hosting.download_dataset(dataset_id)
+
     return MinariDataset(data_path)
 
 

--- a/tests/dataset/test_dataset_download.py
+++ b/tests/dataset/test_dataset_download.py
@@ -61,3 +61,21 @@ def test_download_dataset_from_farama_server(dataset_id: str):
     minari.delete_dataset(dataset_id)
     local_datasets = minari.list_local_datasets()
     assert dataset_id not in local_datasets
+
+
+@pytest.mark.parametrize(
+    "dataset_id",
+    [
+        get_latest_compatible_dataset_id(env_name=env_name, dataset_name="human")
+        for env_name in env_names
+    ],
+)
+def test_load_dataset_with_download(dataset_id: str):
+    """Test load dataset with and without download."""
+    with pytest.raises(FileNotFoundError):
+        dataset = minari.load_dataset(dataset_id)
+
+    dataset = minari.load_dataset(dataset_id, download=True)
+    assert isinstance(dataset, MinariDataset)
+
+    minari.delete_dataset(dataset_id)


### PR DESCRIPTION
# Description

Wanted a small issue/feature to work on and trying to figure out the pre-commit thing as I don't seem able to commit locally because of pyright issues from other files.  Still can't get the pre-commit thing to work.

Allow download=True to be in load_dataset().  Maybe it should be True by default for usability in general but regardless, raise FileNotFound as it did before. 

Fixes #36 

## Type of change

> Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
