### PR TITLE
Update docs for collecting usage in basic usages

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -9,7 +9,11 @@ Minari is a standard dataset hosting interface for Offline Reinforcement Learnin
 
 ## Installation
 
-To install the most recent version of the Minari library run this command: `pip install minari`
+To install the most recent version of the Minari library run this command:
+
+```bash
+pip install minari
+```
 
 The beta release is currently under development. If you'd like to start testing or contribute to Minari then please install this project from source with:
 
@@ -29,6 +33,10 @@ We support Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS.
 Minari can abstract the data collection process. This is achieved by using the :class:`minari.DataCollectorV0` wrapper which stores the environments stepping data in internal memory buffers before saving the dataset into disk. The :class:`minari.DataCollectorV0` wrapper can also perform caching by scheduling the amount of episodes or steps that are stored in-memory before saving the data in a temporary `Minari dataset file </content/dataset_standards>`_ . This wrapper also computes relevant metadata of the dataset while collecting the data. 
 
 The wrapper is very simple to initialize:
+```
+
+```bash
+pip install gymnasium
 ```
 
 ```python


### PR DESCRIPTION
# Description

## What I did
Added a step to install "gymnasium" in docs/content/basic_usage.md

## Why I did
During the "collecting usage" step, I face the following problem, which I will try to resolve.

```
$ python sample.py

Traceback (most recent call last):
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/box2d/bipedal_walker.py", line 15, in <module>
    import Box2D
ModuleNotFoundError: No module named 'Box2D'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/sakakibara/Minari/sample.py", line 5, in <module>
    env = gym.make('LunarLander-v2')
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/registration.py", line 756, in make
    env_creator = load_env_creator(env_spec.entry_point)
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/registration.py", line 545, in load_env_creator
    mod = importlib.import_module(mod_name)
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/box2d/__init__.py", line 1, in <module>
    from gymnasium.envs.box2d.bipedal_walker import BipedalWalker, BipedalWalkerHardcore
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/box2d/bipedal_walker.py", line 25, in <module>
    raise DependencyNotInstalled(
gymnasium.error.DependencyNotInstalled: Box2D is not installed, run `pip install gymnasium[box2d]`
```


## About My Development Environment
- Python 3.9.13
- pyenv 2.3.22-1-g51166377
- pip 22.0.4 from /home/sakakibara/Minari/Minari/.Minari/lib/python3.9/site-packages/pip (python 3.9)
- Ubuntu 22.04.2 LTS

## How I reproduce
```python
# sample.py
from minari import DataCollectorV0
import gymnasium as gym

env = gym.make('LunarLander-v2')
env = DataCollectorV0(env, record_infos=True, max_buffer_steps=100000)
```

```bash
$ pyenv local 3.9.13
$ python -m venv Minari
$ pip install minari
$ python sample.py
```

## Results
Expected Result: 
Instance env of DataCollectorV0 is created.

Actual Result:
the below problem is happened.

```bash
Traceback (most recent call last):
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/box2d/bipedal_walker.py", line 15, in <module>
    import Box2D
ModuleNotFoundError: No module named 'Box2D'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/sakakibara/Minari/sample.py", line 5, in <module>
    env = gym.make('LunarLander-v2')
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/registration.py", line 756, in make
    env_creator = load_env_creator(env_spec.entry_point)
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/registration.py", line 545, in load_env_creator
    mod = importlib.import_module(mod_name)
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/box2d/__init__.py", line 1, in <module>
    from gymnasium.envs.box2d.bipedal_walker import BipedalWalker, BipedalWalkerHardcore
  File "/home/sakakibara/.pyenv/versions/3.9.13/lib/python3.9/site-packages/gymnasium/envs/box2d/bipedal_walker.py", line 25, in <module>
    raise DependencyNotInstalled(
gymnasium.error.DependencyNotInstalled: Box2D is not installed, run `pip install gymnasium[box2d]`
```

## Type of change

- This change requires a documentation update

### Screenshots

| Before | After |
| ----------- | ----------- |
| ![minari-b1c](https://github.com/Farama-Foundation/Minari/assets/44042754/19718f8a-618d-45d2-aefd-2dc5d53da082) | ![minari-1c](https://github.com/Farama-Foundation/Minari/assets/44042754/4f8a9df7-d71f-4d6e-962e-227bbeea6d95)
| ![minari-b2c](https://github.com/Farama-Foundation/Minari/assets/44042754/b3c9c5a6-58f8-46ed-a603-9c347d4a00bd) | ![minari-2c](https://github.com/Farama-Foundation/Minari/assets/44042754/fe4281ee-7bce-476a-a5cc-fc691305e6bb)


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
