### PR TITLE
change create dataset from buffer to ensure same behavior with create data from env

### DIFF
--- a/minari/utils.py
+++ b/minari/utils.py
@@ -380,7 +380,7 @@ def create_dataset_from_buffers(
         * `terminations`: np.ndarray of step terminations. shape = (total_episode_steps + 1, 1).
         * `truncations`: np.ndarray of step truncations. shape = (total_episode_steps + 1, 1).
 
-    If the last trjaectory is neither terminated or truncated, the last step will be marked as truncated.
+    If the last trajectory is neither terminated or truncated, the last step will be marked as truncated.
     Other additional items can be added as long as the values are np.ndarray's or other nested dictionaries.
 
     Args:

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -455,7 +455,7 @@ def create_dataset_from_buffers(
         with h5py.File(data_path, "w", track_order=True) as file:
             for i, eps_buff in enumerate(buffer):
                 # check episode terminated or truncated
-                if_term_or_trunc = eps_buff["terminations"] or eps_buff["truncations"]
+                if_term_or_trunc = eps_buff["terminations"][-1] or eps_buff["truncations"][-1]
                 if_last_eps = (i == (len(buffer) - 1))
                 if if_last_eps and not if_term_or_trunc:
                     warnings.warn(

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -380,6 +380,7 @@ def create_dataset_from_buffers(
         * `terminations`: np.ndarray of step terminations. shape = (total_episode_steps + 1, 1).
         * `truncations`: np.ndarray of step truncations. shape = (total_episode_steps + 1, 1).
 
+    If the last trjaectory is neither terminated or truncated, the last step will be marked as truncated.
     Other additional items can be added as long as the values are np.ndarray's or other nested dictionaries.
 
     Args:

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -456,8 +456,10 @@ def create_dataset_from_buffers(
         with h5py.File(data_path, "w", track_order=True) as file:
             for i, eps_buff in enumerate(buffer):
                 # check episode terminated or truncated
-                if_term_or_trunc = eps_buff["terminations"][-1] or eps_buff["truncations"][-1]
-                if_last_eps = (i == (len(buffer) - 1))
+                if_term_or_trunc = (
+                    eps_buff["terminations"][-1] or eps_buff["truncations"][-1]
+                )
+                if_last_eps = i == (len(buffer) - 1)
                 if if_last_eps and not if_term_or_trunc:
                     warnings.warn(
                         f"The last episode {i} is not terminated or truncated. The last step will be marked as truncated.",


### PR DESCRIPTION
# Description

Hi, 

I think it would be better to keep `create_from_buffer` and `create_from_collevtor_env` having same bahavior.  If we create dataset from collector env, the last episode will be marked as truncated if it's incomplete trajectory. But if create dataset from replay buffers, incomplete trajector will be rejected. 


## Type of change

> Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Screenshots


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
