### PR TITLE
remove/loose typing_extensions dependency requirement

### DIFF
--- a/minari/data_collector/callbacks/step_data.py
+++ b/minari/data_collector/callbacks/step_data.py
@@ -1,5 +1,4 @@
-from typing import Any, Dict, Optional
-from typing import TypedDict
+from typing import Any, Dict, Optional, TypedDict
 
 import gymnasium as gym
 

--- a/minari/data_collector/callbacks/step_data.py
+++ b/minari/data_collector/callbacks/step_data.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, Optional
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 import gymnasium as gym
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "numpy >=1.21.0",
     "h5py>=3.8.0",
     "tqdm>=4.65.0",
-    "typing_extensions==4.4.0",
+    "typing_extensions>=4.4.0",
     "google-cloud-storage==2.5.0",
     "typer[all]==0.9.0",
     "gymnasium>=0.28.1",


### PR DESCRIPTION
# Description

Hi, as discussed in https://github.com/Farama-Foundation/Minari/issues/145,  I think we should loose the requirement of typing_extension for compatibility consideration with other packages.  It will cause problem of typing_extension version frequently.


## Type of change

- Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
