### PR TITLE
Add custom space serialization tutorial

### DIFF
--- a/docs/tutorials/dataset_creation/custom_space_serialization.py
+++ b/docs/tutorials/dataset_creation/custom_space_serialization.py
@@ -49,11 +49,9 @@ print(f"Action space: {env.action_space}")
 # If we take a look at Minari's `serialization functions <https://github.com/Farama-Foundation/Minari/blob/main/minari/serialization.py#L13>`_
 # we can see that ``Dict``, ``Discrete``, and ``Box`` are all supported. However ``MissionSpace`` is not
 # supported and if try to serialize it with:
-
-# %%
-serialize_space(env.observation_space['mission'])
-
-# %% [markdown]
+#
+#  serialize_space(env.observation_space['mission'])
+#
 # Then we will encounter a ``NotImplementedError`` error:
 #
 #   NotImplementedError: No serialization method available for MissionSpace(<function EmptyEnv._gen_mission at 0x12253a940>, None)
@@ -139,16 +137,22 @@ dataset = minari.create_dataset_from_collector_env(
 )
 
 # %% [markdown]
-# To get an idea of what the serialization is doing under the hood we can directly call
-# the ``serialize_custom_space`` function we defined earlier and see the JSON string it returns.
+# To show that the custom space was properly serialized we
+# can load the dataset we just created and take a look at
+# the observation space.
 
 # %%
-serialize_custom_space(env.observation_space['mission'])
+del dataset
+dataset = minari.load_dataset(dataset_id)
+
+print(dataset.spec.observation_space)
 
 # %% [markdown]
-# The output should show our custom observation space object as a string:
+# The output should show the original observation space from earlier
+# except with a different ``MissionSpace`` function name since
+# we created it inside ``deserialize_custom_space``:
 #
-#  '{"type": "MissionSpace", "mission_func": "get to the green goal square"}'
+#  Dict('direction': Discrete(4), 'image': Box(0, 255, (7, 7, 3), uint8), 'mission': MissionSpace(<function deserialize_custom_space.<locals>.<lambda> at 0x11f2608b0>, None))
 #
 # Finally to clean things up, we'll delete the dataset we created earlier:
 

--- a/docs/tutorials/dataset_creation/custom_space_serialization.py
+++ b/docs/tutorials/dataset_creation/custom_space_serialization.py
@@ -82,6 +82,8 @@ env.observation_space['mission'].sample()
 # and also deserialize it back into the custom space.
 
 # %%
+
+
 @serialize_space.register(MissionSpace)
 def serialize_custom_space(space: MissionSpace, to_string=True) -> Union[Dict, str]:
     result = {}
@@ -96,7 +98,7 @@ def serialize_custom_space(space: MissionSpace, to_string=True) -> Union[Dict, s
 @deserialize_space.register("MissionSpace")
 def deserialize_custom_space(space_dict: Dict) -> MissionSpace:
     assert space_dict["type"] == "MissionSpace"
-    mission_func = lambda : space_dict["mission_func"]
+    mission_func = lambda: space_dict["mission_func"]  # noqa: E731
 
     return MissionSpace(
         mission_func=mission_func
@@ -106,6 +108,8 @@ def deserialize_custom_space(space_dict: Dict) -> MissionSpace:
 # Now that we have serialization functions for ``MissionSpace`` we can collect some episode data.
 
 # %%
+
+
 dataset_id = "minigrid-custom-space-v0"
 
 env = DataCollectorV0(env)

--- a/docs/tutorials/dataset_creation/custom_space_serialization.py
+++ b/docs/tutorials/dataset_creation/custom_space_serialization.py
@@ -1,0 +1,188 @@
+# fmt: off
+"""
+Serializing a custom space
+=========================================
+"""
+# %%%
+# In this tutorial you'll learn how to serialize a custom Gym observation space and use that
+# to create a Minari dataset with :class:`minari.DataCollectorV0`. We'll use the
+# simple `CartPole-v1 <https://gymnasium.farama.org/environments/classic_control/cart_pole/>`_ environment,
+# modify the observation space, show how to serialize it, and create a Minari dataset.
+# 
+# Serializing a custom space can be applied to both observation and action spaces.
+# 
+# Let's get started by importing the required modules:
+
+# %%
+import gymnasium as gym
+from typing import Any, Sequence, Union, Dict
+import json
+import numpy as np
+from gymnasium.spaces import Space
+from numpy.typing import NDArray
+
+import minari
+from minari import DataCollectorV0
+from minari.serialization import serialize_space, deserialize_space
+from minari.data_collector.callbacks import StepDataCallback
+
+# %% [markdown]
+# First we'll initialize the CartPole environment and take a look at its observation and action space.
+
+# %%
+env = gym.make("CartPole-v1")
+
+print(f"Observation space: {env.observation_space}")
+print(f"Observation space: {env.action_space}")
+
+# %% [markdown]
+# Now we can create a new observation space that inherits from the `gym.Space <https://gymnasium.farama.org/api/spaces/#the-base-class>`_ class.
+
+# %%
+class CartPoleObservationSpace(Space):
+    def __init__(
+        self,
+        low: NDArray[Any],
+        high: NDArray[Any],
+        shape: Sequence[int],
+        dtype: type[np.floating[Any]] = np.float32,
+    ):
+        self.low = np.full(shape, low, dtype=dtype)
+        self.high = np.full(shape, high, dtype=dtype)
+        super().__init__(shape, dtype)
+
+    def sample(self) -> NDArray[Any]:
+        """Sample a random observation according to low/high boundaries"""
+        sample = np.empty(self.shape)
+        sample = self.np_random.uniform(low=self.low, high=self.high, size=self.shape)
+        return sample.astype(self.dtype)
+
+    def contains(self, x: Any) -> bool:
+        """Return boolean specifying if x is a valid member of this space"""
+        if not isinstance(x, np.ndarray):
+            try:
+                x = np.asarray(x, dtype=self.dtype)
+            except (ValueError, TypeError):
+                return False
+
+        return bool(
+            np.can_cast(x.dtype, self.dtype)
+            and x.shape == self.shape
+            and np.all(x >= self.low)
+            and np.all(x <= self.high)
+        )
+
+# %% [markdown]
+# Now that we have a custom observation space we need to define functions that properly serialize it.
+# 
+# When creating a Minari dataset, the space data gets `serialized <https://minari.farama.org/content/dataset_standards/#space-serialization>`_ to a JSON format when saving to disk. The `serialize_space <https://github.com/Farama-Foundation/Minari/blob/main/minari/serialization.py#L13C5-L13C20>`_ function takes care of this conversion for various supported Gym spaces. To enable serialization for a custom space we can register 2 new functions that will serialize the space into a JSON object and also deserialize it into our custom space object.
+
+# %%
+@serialize_space.register(CartPoleObservationSpace)
+def serialize_custom_space(space: CartPoleObservationSpace, to_string=True) -> Union[Dict, str]:
+    result = {}
+    result["type"] = "CartPoleObservationSpace"
+    result["dtype"] = str(space.dtype)
+    result["shape"] = space.shape
+    result["low"] = space.low.tolist()
+    result["high"] = space.high.tolist()
+
+    if to_string:
+        result = json.dumps(result)
+    return result
+
+@deserialize_space.register("CartPoleObservationSpace")
+def deserialize_custom_space(space_dict: Dict) -> CartPoleObservationSpace:
+    assert space_dict["type"] == "CartPoleObservationSpace"
+    dtype = space_dict["dtype"]
+    shape = space_dict["shape"]
+    low = np.array(space_dict["low"])
+    high = np.array(space_dict["high"])
+    return CartPoleObservationSpace(
+        low=low,
+        high=high,
+        shape=shape,
+        dtype=dtype
+    )
+
+# %% [markdown]
+# Now we can initialize the custom observation space for our environment and collect some episode data.
+# 
+# The x-position of CartPole's observation space can take values between -4.8 and +4.8.
+# For this tutorial we'll use our new class to create an observation space where the
+# cart's x-position can only take on values between 0 and +4.8.
+# 
+# We also need to define a :class:`minari.StepDataCallback` object to manipulate the x-position to be
+# above 0.
+#
+# First element in array is x-position. The rest of elements are CartPole's default values
+
+# %%
+custom_observation_space = CartPoleObservationSpace(
+    low=np.array([0, -3.4028235e+38, -4.1887903e-01, -3.4028235e+38], dtype=np.float32),
+    high=np.array([4.8, 3.4028235e+38, 4.1887903e-01, 3.4028235e+38], dtype=np.float32),
+    shape=(4,),
+    dtype=np.float32
+)
+
+class CustomSpaceStepDataCallback(StepDataCallback):
+    def __call__(self, env, **kwargs):
+        step_data = super().__call__(env, **kwargs)
+        step_data["observations"][0] = max(step_data["observations"][0], 0)
+        return step_data
+
+# %%
+dataset_id = "cartpole-custom-space-v1"
+
+# delete the test dataset if it already exists
+local_datasets = minari.list_local_datasets()
+if dataset_id in local_datasets:
+    minari.delete_dataset(dataset_id)
+
+env = DataCollectorV0(
+    env,
+    observation_space=custom_observation_space,
+    step_data_callback=CustomSpaceStepDataCallback
+)
+num_episodes = 10
+
+env.reset(seed=42)
+
+for episode in range(num_episodes):
+    terminated = False
+    truncated = False
+    while not terminated and not truncated:
+        action = env.action_space.sample()  # Choose random actions
+        _, _, terminated, truncated, _ = env.step(action)
+    env.reset()
+
+# %% [markdown]
+# Now that we have collected some episode data we can create a Minari dataset and take a look at a sample episode.
+
+# %%
+dataset = minari.create_dataset_from_collector_env(
+    dataset_id=dataset_id,
+    collector_env=env,
+    algorithm_name="random_policy",
+    author="Farama",
+    author_email="contact@farama.org",
+    code_permalink="https://github.com/Farama-Foundation/Minari/blob/main/docs/tutorials/dataset_creation/custom_space_serialization.py"
+)
+
+ep = dataset.sample_episodes(1)
+print(f"Min x-position: {ep[0].observations[:, 0].min():.2f}")
+
+# %%
+# The output from the above section will take a sampled episode and show the minimum x-position for a sampled episode being greater than or equal to 0.
+#
+#   Min x-position: 0.00
+#
+# To get an idea of what the serialization is doing under the hood we can directly call
+# the `serialize_custom_space` function we defined earlier and see the JSON string it returns.
+
+# %%
+serialize_custom_space(custom_observation_space)
+# %%
+# The output should show our custom observation space object as a string:
+#
+#  '{"type": "CartPoleObservationSpace", "dtype": "float32", "shape": [4], "low": [0.0, -3.4028234663852886e+38, -0.41887903213500977, -3.4028234663852886e+38], "high": [4.800000190734863, 3.4028234663852886e+38, 0.41887903213500977, 3.4028234663852886e+38]}'

--- a/docs/tutorials/dataset_creation/custom_space_serialization.py
+++ b/docs/tutorials/dataset_creation/custom_space_serialization.py
@@ -13,18 +13,20 @@ Serializing a custom space
 # 
 # Let's get started by importing the required modules:
 
+import json
+from typing import Any, Dict, Sequence, Union
+
 # %%
 import gymnasium as gym
-from typing import Any, Sequence, Union, Dict
-import json
 import numpy as np
 from gymnasium.spaces import Space
 from numpy.typing import NDArray
 
 import minari
 from minari import DataCollectorV0
-from minari.serialization import serialize_space, deserialize_space
 from minari.data_collector.callbacks import StepDataCallback
+from minari.serialization import deserialize_space, serialize_space
+
 
 # %% [markdown]
 # First we'll initialize the CartPole environment and take a look at its observation and action space.

--- a/docs/tutorials/dataset_creation/custom_space_serialization.py
+++ b/docs/tutorials/dataset_creation/custom_space_serialization.py
@@ -8,9 +8,9 @@ Serializing a custom space
 # to create a Minari dataset with :class:`minari.DataCollectorV0`. We'll use the
 # simple `CartPole-v1 <https://gymnasium.farama.org/environments/classic_control/cart_pole/>`_ environment,
 # modify the observation space, show how to serialize it, and create a Minari dataset.
-# 
+#
 # Serializing a custom space can be applied to both observation and action spaces.
-# 
+#
 # Let's get started by importing the required modules:
 
 import json
@@ -41,6 +41,8 @@ print(f"Observation space: {env.action_space}")
 # Now we can create a new observation space that inherits from the `gym.Space <https://gymnasium.farama.org/api/spaces/#the-base-class>`_ class.
 
 # %%
+
+
 class CartPoleObservationSpace(Space):
     def __init__(
         self,
@@ -76,10 +78,15 @@ class CartPoleObservationSpace(Space):
 
 # %% [markdown]
 # Now that we have a custom observation space we need to define functions that properly serialize it.
-# 
-# When creating a Minari dataset, the space data gets `serialized <https://minari.farama.org/content/dataset_standards/#space-serialization>`_ to a JSON format when saving to disk. The `serialize_space <https://github.com/Farama-Foundation/Minari/blob/main/minari/serialization.py#L13C5-L13C20>`_ function takes care of this conversion for various supported Gym spaces. To enable serialization for a custom space we can register 2 new functions that will serialize the space into a JSON object and also deserialize it into our custom space object.
+#
+# When creating a Minari dataset, the space data gets `serialized <https://minari.farama.org/content/dataset_standards/#space-serialization>`_
+# to a JSON format when saving to disk. The `serialize_space <https://github.com/Farama-Foundation/Minari/blob/main/minari/serialization.py#L13C5-L13C20>`_
+# function takes care of this conversion for various supported Gym spaces. To enable serialization for a custom space we can register 2 new functions that
+# will serialize the space into a JSON object and also deserialize it into our custom space object.
 
 # %%
+
+
 @serialize_space.register(CartPoleObservationSpace)
 def serialize_custom_space(space: CartPoleObservationSpace, to_string=True) -> Union[Dict, str]:
     result = {}
@@ -92,6 +99,7 @@ def serialize_custom_space(space: CartPoleObservationSpace, to_string=True) -> U
     if to_string:
         result = json.dumps(result)
     return result
+
 
 @deserialize_space.register("CartPoleObservationSpace")
 def deserialize_custom_space(space_dict: Dict) -> CartPoleObservationSpace:
@@ -109,23 +117,26 @@ def deserialize_custom_space(space_dict: Dict) -> CartPoleObservationSpace:
 
 # %% [markdown]
 # Now we can initialize the custom observation space for our environment and collect some episode data.
-# 
+#
 # The x-position of CartPole's observation space can take values between -4.8 and +4.8.
 # For this tutorial we'll use our new class to create an observation space where the
 # cart's x-position can only take on values between 0 and +4.8.
-# 
+#
 # We also need to define a :class:`minari.StepDataCallback` object to manipulate the x-position to be
 # above 0.
 #
 # First element in array is x-position. The rest of elements are CartPole's default values
 
 # %%
+
+
 custom_observation_space = CartPoleObservationSpace(
     low=np.array([0, -3.4028235e+38, -4.1887903e-01, -3.4028235e+38], dtype=np.float32),
     high=np.array([4.8, 3.4028235e+38, 4.1887903e-01, 3.4028235e+38], dtype=np.float32),
     shape=(4,),
     dtype=np.float32
 )
+
 
 class CustomSpaceStepDataCallback(StepDataCallback):
     def __call__(self, env, **kwargs):
@@ -134,6 +145,8 @@ class CustomSpaceStepDataCallback(StepDataCallback):
         return step_data
 
 # %%
+
+
 dataset_id = "cartpole-custom-space-v1"
 
 # delete the test dataset if it already exists


### PR DESCRIPTION
# Description

This PR adds a new tutorial that goes over serializing custom Gym spaces and shows an example of how to apply a custom observation space to the CartPole environment.

## Type of change

> Please delete options that are not relevant.

- This change requires a documentation update

### Screenshots

Screenshot of tutorial page:
<img width="1129" alt="Screenshot 2023-10-10 at 10 08 12 PM" src="https://github.com/Farama-Foundation/Minari/assets/12959255/575c3093-f710-4f4d-8668-0f9f51bf7459">


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
