### PR TITLE
Add obs/act spaces when combining datasets

### DIFF
--- a/minari/utils.py
+++ b/minari/utils.py
@@ -156,13 +156,15 @@ def validate_datasets_to_combine(datasets_to_combine: List[MinariDataset]) -> En
     Tests if the datasets were created with the same environment (`env_spec`) and re-calculates the
     `max_episode_steps` argument.
 
+    Also checks that the datasets obs/act spaces are the same.
+
     Args:
         datasets_to_combine (List[MinariDataset]): list of MinariDataset to combine
 
     Returns:
         combined_dataset_env_spec (EnvSpec): the resulting EnvSpec of combining the MinariDatasets
     """
-    assert all(isinstance(dataset, MinariDataset) for dataset in datasets_to_combine)
+    assert all(isinstance(dataset, MinariDataset) for dataset in datasets_to_combine), f"Some of the datasets to combine are not of type {MinariDataset}"
 
     # Check if there are any `None` max_episode_steps
     if any(
@@ -184,6 +186,10 @@ def validate_datasets_to_combine(datasets_to_combine: List[MinariDataset]) -> En
     assert all(
         env_spec == combine_env_spec[0] for env_spec in combine_env_spec
     ), "The datasets to be combined have different values for `env_spec` attribute."
+
+    # Check that all datasets have the same action/observation space
+    assert all(dataset.action_space == datasets_to_combine[0].action_space for dataset in datasets_to_combine), "The dataset to combine must have the same action space"
+    assert all(dataset.observation_space == datasets_to_combine[0].observation_space for dataset in datasets_to_combine), "The dataset to combine must have the same observation space"
 
     return combine_env_spec[0]
 
@@ -228,7 +234,9 @@ def combine_datasets(datasets_to_combine: List[MinariDataset], new_dataset_id: s
     new_dataset_path = get_dataset_path(new_dataset_id)
     new_dataset_path.mkdir()
     new_storage = MinariStorage.new(
-        new_dataset_path.joinpath("data"), env_spec=combined_dataset_env_spec
+        new_dataset_path.joinpath("data"), env_spec=combined_dataset_env_spec,
+        observation_space=datasets_to_combine[0].observation_space,
+        action_space=datasets_to_combine[0].action_space
     )
 
     new_storage.update_metadata(

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -188,9 +188,10 @@ def validate_datasets_to_combine(datasets_to_combine: List[MinariDataset]) -> En
     ), "The datasets to be combined have different values for `env_spec` attribute."
 
     # Check that all datasets have the same action/observation space
-    assert all(dataset.action_space == datasets_to_combine[0].action_space for dataset in datasets_to_combine), "The datasets to combine must have the same action space"
-    assert all(dataset.observation_space == datasets_to_combine[0].observation_space for dataset in datasets_to_combine), "The datasets to combine must have the same observation space"
-
+    if any(dataset.action_space != datasets_to_combine[0].action_space for dataset in datasets_to_combine):
+        raise ValueError("The datasets to combine must have the same action space.")
+    if any(dataset.observation_space != datasets_to_combine[0].observation_space for dataset in datasets_to_combine):
+        raise ValueError("The datasets to combine must have the same observation space.")
     return combine_env_spec[0]
 
 

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -188,8 +188,8 @@ def validate_datasets_to_combine(datasets_to_combine: List[MinariDataset]) -> En
     ), "The datasets to be combined have different values for `env_spec` attribute."
 
     # Check that all datasets have the same action/observation space
-    assert all(dataset.action_space == datasets_to_combine[0].action_space for dataset in datasets_to_combine), "The dataset to combine must have the same action space"
-    assert all(dataset.observation_space == datasets_to_combine[0].observation_space for dataset in datasets_to_combine), "The dataset to combine must have the same observation space"
+    assert all(dataset.action_space == datasets_to_combine[0].action_space for dataset in datasets_to_combine), "The datasets to combine must have the same action space"
+    assert all(dataset.observation_space == datasets_to_combine[0].observation_space for dataset in datasets_to_combine), "The datasets to combine must have the same observation space"
 
     return combine_env_spec[0]
 


### PR DESCRIPTION
# Description

Datasets should have the same observation and action space before being combined. The spaces should also be stored as an attribute in case the dataset has different spaces from the env used to create the dataset (then spaces shouldn't be inferred when loading the dataset)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
