### PR TITLE
Deprecate create_dataset_from_collector_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ for _ in range(100):
         obs, rew, terminated, truncated, info = env.step(action)
         done = terminated or truncated
 
-dataset = minari.create_dataset_from_collector_env("LunarLander-v2-test-v0", env)
+dataset = env.create_dataset("LunarLander-v2-test-v0")
 ```
 
 For other examples, see [Basic Usage](https://minari.farama.org/main/content/basic_usage/). For a complete tutorial on how to create new datasets using Minari, see our [Pointmaze D4RL Dataset](https://minari.farama.org/main/tutorials/dataset_creation/point_maze_dataset/) tutorial, which re-creates the Maze2D datasets from [D4RL](https://github.com/Farama-Foundation/D4RL).

--- a/docs/api/data_collector.md
+++ b/docs/api/data_collector.md
@@ -22,6 +22,7 @@ data_collector_callbacks/episode_metadata_callback
 .. autofunction:: minari.DataCollectorV0.step
 .. autofunction:: minari.DataCollectorV0.reset
 .. autofunction:: minari.DataCollectorV0.close
+.. autofunction:: minari.DataCollectorV0.create_dataset
 .. autofunction:: minari.DataCollectorV0.save_to_disk
 .. autofunction:: minari.DataCollectorV0.clear_buffer_to_tmp_file
 .. autofunction::minari.DataCollectorV0._add_to_episode_buffer

--- a/docs/api/data_collector.md
+++ b/docs/api/data_collector.md
@@ -23,7 +23,6 @@ data_collector_callbacks/episode_metadata_callback
 .. autofunction:: minari.DataCollectorV0.reset
 .. autofunction:: minari.DataCollectorV0.close
 .. autofunction:: minari.DataCollectorV0.create_dataset
-.. autofunction:: minari.DataCollectorV0.save_to_disk
 .. autofunction:: minari.DataCollectorV0.clear_buffer_to_tmp_file
 .. autofunction::minari.DataCollectorV0._add_to_episode_buffer
 ```

--- a/docs/api/minari_functions.md
+++ b/docs/api/minari_functions.md
@@ -10,7 +10,6 @@ minari_dataset/episode_data
 ## Create Minari Dataset
 
 ```{eval-rst}
-.. autofunction:: env.create_dataset
 .. autofunction:: minari.create_dataset_from_buffers
 ```
 

--- a/docs/api/minari_functions.md
+++ b/docs/api/minari_functions.md
@@ -10,7 +10,7 @@ minari_dataset/episode_data
 ## Create Minari Dataset
 
 ```{eval-rst}
-.. autofunction:: minari.create_dataset_from_collector_env
+.. autofunction:: env.create_dataset
 .. autofunction:: minari.create_dataset_from_buffers
 ```
 

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -52,7 +52,7 @@ In this example, the :class:`minari.DataCollectorV0` wraps the `'CartPole-v1'` e
 ```{eval-rst}
 To create a Minari dataset first we need to step the environment with a given policy to allow the :class:`minari.DataCollectorV0` to record the data that will comprise the dataset. This is as simple as just looping through the Gymansium MDP API. For our example we will loop through ``100`` episodes of the ``'CartPole-v1'`` environment with a random policy.
 
-Finally, we need to create the Minari dataset and give it a name id. This is done by calling the :func:`minari.create_dataset_from_collector_env` Minari function which will move the temporary data recorded in the :class:`minari.DataCollectorV0` environment to a permanent location in the `local Minari root path </content/dataset_standards>`_ with the Minari dataset standard structure.
+Finally, we need to create the Minari dataset and give it a name id. This is done by calling the :func:`env.create_dataset` Minari function which will move the temporary data recorded in the :class:`minari.DataCollectorV0` environment to a permanent location in the `local Minari root path </content/dataset_standards>`_ with the Minari dataset standard structure.
 
 Extending the code example for the ``'CartPole-v1'`` environment we can create the Minari dataset as follows:
 ```
@@ -77,8 +77,7 @@ for _ in range(total_episodes):
         if terminated or truncated:
             break
 
-dataset = minari.create_dataset_from_collector_env(dataset_id="CartPole-v1-test-v0",
-                                                   collector_env=env,
+dataset = env.create_dataset(dataset_id="CartPole-v1-test-v0",
                                                    algorithm_name="Random-Policy",
                                                    code_permalink="https://github.com/Farama-Foundation/Minari",
                                                    author="Farama",
@@ -88,7 +87,7 @@ dataset = minari.create_dataset_from_collector_env(dataset_id="CartPole-v1-test-
 ```{eval-rst}
 When creating the Minari dataset additional metadata can be added such as the ``algorithm_name`` used to compute the actions, a ``code_permalink`` with a link to the code used to generate the dataset, as well as the ``author`` and ``author_email``.
 
-The :func:`minari.create_dataset_from_collector_env` function returns a :class:`minari.MinariDataset` object, ``dataset`` in the previous code snippet.
+The :func:`env.create_dataset` function returns a :class:`minari.MinariDataset` object, ``dataset`` in the previous code snippet.
 
 Once the dataset has been created we can check if the Minari dataset id appears in the list of local datasets:
 ```
@@ -109,10 +108,10 @@ There is another optional way of creating a Minari dataset and that is by using 
 ### Checkpoint Minari Dataset
 
 ```{eval-rst}
-When collecting data with the :class:`minari.DataCollectorV0` wrapper, the recorded data is saved into temporary files and it won't be permanently saved in disk until the :func:`minari.create_dataset_from_collector_env` function is called. For large datasets, to avoid losing all of the collected data, extra data from a :class:`minari.DataCollectorV0` can be appended to checkpoint the data collection process.
+When collecting data with the :class:`minari.DataCollectorV0` wrapper, the recorded data is saved into temporary files and it won't be permanently saved in disk until the :func:`env.create_dataset` function is called. For large datasets, to avoid losing all of the collected data, extra data from a :class:`minari.DataCollectorV0` can be appended to checkpoint the data collection process.
 
 
-To checkpoint a dataset we can call the :func:`minari.MinariDataset.update_dataset_from_collector_env` method. Every time the function :func:`minari.create_dataset_from_collector_env` or the method :func:`minari.MinariDataset.update_dataset_from_collector_env` are called, the buffers from the :class:`minari.DataCollectorV0` environment are cleared.
+To checkpoint a dataset we can call the :func:`minari.MinariDataset.update_dataset_from_collector_env` method. Every time the function :func:`env.create_dataset` or the method :func:`minari.MinariDataset.update_dataset_from_collector_env` are called, the buffers from the :class:`minari.DataCollectorV0` environment are cleared.
 
 Continuing the ``'CartPole-v1'`` example we can checkpoint the newly created Minari dataset every 10 episodes as follows:
 ```
@@ -145,8 +144,7 @@ for episode_id in range(total_episodes):
         # Update local Minari dataset every 10 episodes.
         # This works as a checkpoint to not lose the already collected data
         if dataset is None:
-            dataset = minari.create_dataset_from_collector_env(dataset_id=dataset_name,
-                                                    collector_env=env,
+            dataset = env.create_dataset(dataset_id=dataset_name,
                                                     algorithm_name="Random-Policy",
                                                     code_permalink="https://github.com/Farama-Foundation/Minari",
                                                     author="Farama",

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -52,7 +52,7 @@ In this example, the :class:`minari.DataCollectorV0` wraps the `'CartPole-v1'` e
 ```{eval-rst}
 To create a Minari dataset first we need to step the environment with a given policy to allow the :class:`minari.DataCollectorV0` to record the data that will comprise the dataset. This is as simple as just looping through the Gymansium MDP API. For our example we will loop through ``100`` episodes of the ``'CartPole-v1'`` environment with a random policy.
 
-Finally, we need to create the Minari dataset and give it a name id. This is done by calling the :func:`env.create_dataset` Minari function which will move the temporary data recorded in the :class:`minari.DataCollectorV0` environment to a permanent location in the `local Minari root path </content/dataset_standards>`_ with the Minari dataset standard structure.
+Finally, we need to create the Minari dataset and give it a name id. This is done by calling the :func:`DataCollectorV0.create_dataset` Minari function which will move the temporary data recorded in the :class:`minari.DataCollectorV0` environment to a permanent location in the `local Minari root path </content/dataset_standards>`_ with the Minari dataset standard structure.
 
 Extending the code example for the ``'CartPole-v1'`` environment we can create the Minari dataset as follows:
 ```
@@ -87,7 +87,7 @@ dataset = env.create_dataset(dataset_id="CartPole-v1-test-v0",
 ```{eval-rst}
 When creating the Minari dataset additional metadata can be added such as the ``algorithm_name`` used to compute the actions, a ``code_permalink`` with a link to the code used to generate the dataset, as well as the ``author`` and ``author_email``.
 
-The :func:`env.create_dataset` function returns a :class:`minari.MinariDataset` object, ``dataset`` in the previous code snippet.
+The :func:`DataCollectorV0.create_dataset` function returns a :class:`minari.MinariDataset` object, ``dataset`` in the previous code snippet.
 
 Once the dataset has been created we can check if the Minari dataset id appears in the list of local datasets:
 ```
@@ -108,10 +108,10 @@ There is another optional way of creating a Minari dataset and that is by using 
 ### Checkpoint Minari Dataset
 
 ```{eval-rst}
-When collecting data with the :class:`minari.DataCollectorV0` wrapper, the recorded data is saved into temporary files and it won't be permanently saved in disk until the :func:`env.create_dataset` function is called. For large datasets, to avoid losing all of the collected data, extra data from a :class:`minari.DataCollectorV0` can be appended to checkpoint the data collection process.
+When collecting data with the :class:`minari.DataCollectorV0` wrapper, the recorded data is saved into temporary files and it won't be permanently saved in disk until the :func:`DataCollectorV0.create_dataset` function is called. For large datasets, to avoid losing all of the collected data, extra data from a :class:`minari.DataCollectorV0` can be appended to checkpoint the data collection process.
 
 
-To checkpoint a dataset we can call the :func:`minari.MinariDataset.update_dataset_from_collector_env` method. Every time the function :func:`env.create_dataset` or the method :func:`minari.MinariDataset.update_dataset_from_collector_env` are called, the buffers from the :class:`minari.DataCollectorV0` environment are cleared.
+To checkpoint a dataset we can call the :func:`minari.MinariDataset.update_dataset_from_collector_env` method. Every time the function :func:`DataCollectorV0.create_dataset` or the method :func:`minari.MinariDataset.update_dataset_from_collector_env` are called, the buffers from the :class:`minari.DataCollectorV0` environment are cleared.
 
 Continuing the ``'CartPole-v1'`` example we can checkpoint the newly created Minari dataset every 10 episodes as follows:
 ```

--- a/docs/tutorials/dataset_creation/custom_space_serialization.py
+++ b/docs/tutorials/dataset_creation/custom_space_serialization.py
@@ -127,9 +127,8 @@ for episode in range(num_episodes):
 # Finally we can create a Minari dataset.
 
 # %%
-dataset = minari.create_dataset_from_collector_env(
+dataset = env.create_dataset(
     dataset_id=dataset_id,
-    collector_env=env,
     algorithm_name="random_policy",
     author="Farama",
     author_email="contact@farama.org",

--- a/docs/tutorials/dataset_creation/observation_space_subseting.py
+++ b/docs/tutorials/dataset_creation/observation_space_subseting.py
@@ -100,9 +100,8 @@ for episode in range(num_episodes):
     env.reset()
 
 # Create Minari dataset and store locally
-dataset = minari.create_dataset_from_collector_env(
+dataset = env.create_dataset(
     dataset_id=dataset_id,
-    collector_env=env,
     algorithm_name="random_policy",
 )
 

--- a/docs/tutorials/dataset_creation/point_maze_dataset.py
+++ b/docs/tutorials/dataset_creation/point_maze_dataset.py
@@ -22,7 +22,6 @@ PointMaze D4RL dataset
 import gymnasium as gym
 import numpy as np
 
-import minari
 from minari import DataCollectorV0, StepDataCallback
 
 
@@ -396,8 +395,7 @@ for n_step in range(int(total_steps)):
 
     obs, rew, terminated, truncated, info = collector_env.step(action)
 
-dataset = minari.create_dataset_from_collector_env(
-    collector_env=collector_env,
+dataset = env.create_dataset(
     dataset_id=dataset_name,
     algorithm_name="QIteration",
     code_permalink="https://github.com/Farama-Foundation/Minari/blob/main/docs/tutorials/dataset_creation/point_maze_dataset.py",

--- a/docs/tutorials/dataset_creation/point_maze_dataset.py
+++ b/docs/tutorials/dataset_creation/point_maze_dataset.py
@@ -395,7 +395,7 @@ for n_step in range(int(total_steps)):
 
     obs, rew, terminated, truncated, info = collector_env.step(action)
 
-dataset = env.create_dataset(
+dataset = collector_env.create_dataset(
     dataset_id=dataset_name,
     algorithm_name="QIteration",
     code_permalink="https://github.com/Farama-Foundation/Minari/blob/main/docs/tutorials/dataset_creation/point_maze_dataset.py",

--- a/docs/tutorials/using_datasets/behavioral_cloning.py
+++ b/docs/tutorials/using_datasets/behavioral_cloning.py
@@ -66,9 +66,8 @@ for i in tqdm(range(total_episodes)):
         if terminated or truncated:
             break
 
-dataset = minari.create_dataset_from_collector_env(
+dataset = env.create_dataset(
     dataset_id="CartPole-v1-expert",
-    collector_env=env,
     algorithm_name="ExpertPolicy",
     code_permalink="https://minari.farama.org/tutorials/behavioral_cloning",
     author="Farama",

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import copy
 import os
 import shutil
 import tempfile
 import warnings
-from typing import Any, Dict, List, Optional, SupportsFloat, Type, Union
+from typing import Any, Callable, Dict, List, Optional, SupportsFloat, Type, Union
 
 import gymnasium as gym
 import numpy as np
 from gymnasium.core import ActType, ObsType
+from gymnasium.envs.registration import EnvSpec
 
 from minari.data_collector.callbacks import (
     STEP_DATA_KEYS,
@@ -18,6 +20,7 @@ from minari.data_collector.callbacks import (
 )
 from minari.dataset.minari_dataset import MinariDataset
 from minari.dataset.minari_storage import MinariStorage
+from minari.utils import _generate_dataset_metadata, _generate_dataset_path
 
 
 EpisodeBuffer = Dict[str, Any]  # TODO: narrow this down
@@ -259,6 +262,70 @@ class DataCollectorV0(gym.Wrapper):
             action_space=self._storage.action_space,
             env_spec=self.env.spec,
         )
+
+    def create_dataset(
+        self,
+        dataset_id: str,
+        eval_env: Optional[str | gym.Env | EnvSpec] = None,
+        algorithm_name: Optional[str] = None,
+        author: Optional[str] = None,
+        author_email: Optional[str] = None,
+        code_permalink: Optional[str] = None,
+        ref_min_score: Optional[float] = None,
+        ref_max_score: Optional[float] = None,
+        expert_policy: Optional[Callable[[ObsType], ActType]] = None,
+        num_episodes_average_score: int = 100,
+        minari_version: Optional[str] = None,
+    ):
+        """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollectorV0` Minari wrapper.
+
+        The ``dataset_id`` parameter corresponds to the name of the dataset, with the syntax as follows:
+        ``(env_name-)(dataset_name)(-v(version))`` where ``env_name`` identifies the name of the environment used to generate the dataset ``dataset_name``.
+        This ``dataset_id`` is used to load the Minari datasets with :meth:`minari.load_dataset`.
+
+        Args:
+            dataset_id (str): name id to identify Minari dataset
+            buffer (list[Dict[str, Union[list, Dict]]]): list of episode dictionaries with data
+            eval_env (Optional[str|gym.Env|EnvSpec]): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) to use for evaluation with the dataset. After loading the dataset, the environment can be recovered as follows: `MinariDataset.recover_environment(eval_env=True).
+                                                    If None the `env` used to collect the buffer data should be used for evaluation.
+            algorithm_name (Optional[str], optional): name of the algorithm used to collect the data. Defaults to None.
+            author (Optional[str], optional): author that generated the dataset. Defaults to None.
+            author_email (Optional[str], optional): email of the author that generated the dataset. Defaults to None.
+            code_permalink (Optional[str], optional): link to relevant code used to generate the dataset. Defaults to None.
+            ref_min_score( Optional[float], optional): minimum reference score from the average returns of a random policy. This value is later used to normalize a score with :meth:`minari.get_normalized_score`. If default None the value will be estimated with a default random policy.
+            ref_max_score (Optional[float], optional: maximum reference score from the average returns of a hypothetical expert policy. This value is used in :meth:`minari.get_normalized_score`. Default None.
+            expert_policy (Optional[Callable[[ObsType], ActType], optional): policy to compute `ref_max_score` by averaging the returns over a number of episodes equal to  `num_episodes_average_score`.
+                                                                            `ref_max_score` and `expert_policy` can't be passed at the same time. Default to None
+            num_episodes_average_score (int): number of episodes to average over the returns to compute `ref_min_score` and `ref_max_score`. Default to 100.
+            minari_version (Optional[str], optional): Minari version specifier compatible with the dataset. If None (default) use the installed Minari version.
+
+        Returns:
+            MinariDataset
+        """
+        dataset_path = _generate_dataset_path(dataset_id)
+        metadata: Dict[str, Any] = _generate_dataset_metadata(
+            dataset_id,
+            copy.deepcopy(self.env.spec),
+            eval_env,
+            algorithm_name,
+            author,
+            author_email,
+            code_permalink,
+            ref_min_score,
+            ref_max_score,
+            expert_policy,
+            num_episodes_average_score,
+            minari_version,
+        )
+
+        self.save_to_disk(dataset_path, metadata)
+
+        # will be able to calculate dataset size only after saving the disk, so updating the dataset metadata post `save_to_disk` method
+
+        dataset = MinariDataset(dataset_path)
+        metadata['dataset_size'] = dataset.storage.get_size()
+        dataset.storage.update_metadata(metadata)
+        return dataset
 
     def save_to_disk(
         self, path: str | os.PathLike, dataset_metadata: Dict[str, Any] = {}

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import warnings
 from typing import Any, Dict, List, Optional, SupportsFloat, Type, Union
 
 import gymnasium as gym
@@ -268,6 +269,7 @@ class DataCollectorV0(gym.Wrapper):
             path (str): path to store the dataset, e.g.: '/home/foo/datasets/data'
             dataset_metadata (Dict, optional): additional metadata to add to the dataset file. Defaults to {}.
         """
+        warnings.warn("This method is deprecated and will become private in v0.5.0.", DeprecationWarning, stacklevel=2)
         self._validate_buffer()
         self._storage.update_episodes(self._buffer)
         self._buffer.clear()

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -20,7 +20,6 @@ from minari.data_collector.callbacks import (
 )
 from minari.dataset.minari_dataset import MinariDataset
 from minari.dataset.minari_storage import MinariStorage
-from minari.utils import _generate_dataset_metadata, _generate_dataset_path
 
 
 EpisodeBuffer = Dict[str, Any]  # TODO: narrow this down
@@ -302,6 +301,8 @@ class DataCollectorV0(gym.Wrapper):
         Returns:
             MinariDataset
         """
+        # TODO: move the import to top of the file after removing minari.create_dataset_from_collector_env() in 0.5.0
+        from minari.utils import _generate_dataset_metadata, _generate_dataset_path
         dataset_path = _generate_dataset_path(dataset_id)
         metadata: Dict[str, Any] = _generate_dataset_metadata(
             dataset_id,

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -48,7 +48,7 @@ class DataCollectorV0(gym.Wrapper):
             if terminated or truncated:
                 env.reset()
 
-        dataset = minari.create_dataset_from_collector_env(dataset_id="env_name-dataset_name-v(version)", collector_env=env, **kwargs)
+        dataset = env.create_dataset(dataset_id="env_name-dataset_name-v(version)", **kwargs)
 
     Some of the characteristics of this wrapper:
 

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -604,7 +604,7 @@ def create_dataset_from_collector_env(
     Returns:
         MinariDataset
     """
-    warnings.warn("This function is deprecated and will be removed in v0.5.0. Please use env.create_dataset() instead.", DeprecationWarning, stacklevel=2)
+    warnings.warn("This function is deprecated and will be removed in v0.5.0. Please use DataCollectorV0.create_dataset() instead.", DeprecationWarning, stacklevel=2)
     assert collector_env.datasets_path is not None
     dataset_path = _generate_dataset_path(dataset_id)
     metadata: Dict[str, Any] = _generate_dataset_metadata(

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -15,7 +15,6 @@ from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
 
-from minari import DataCollectorV0
 from minari.dataset.minari_dataset import MinariDataset
 from minari.dataset.minari_storage import MinariStorage
 from minari.storage.datasets_root_dir import get_dataset_path
@@ -567,7 +566,7 @@ def create_dataset_from_buffers(
 
 def create_dataset_from_collector_env(
     dataset_id: str,
-    collector_env: DataCollectorV0,
+    collector_env: Any,
     eval_env: Optional[str | gym.Env | EnvSpec] = None,
     algorithm_name: Optional[str] = None,
     author: Optional[str] = None,

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -15,6 +15,7 @@ from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
 
+from minari import DataCollectorV0
 from minari.dataset.minari_dataset import MinariDataset
 from minari.dataset.minari_storage import MinariStorage
 from minari.storage.datasets_root_dir import get_dataset_path
@@ -566,7 +567,7 @@ def create_dataset_from_buffers(
 
 def create_dataset_from_collector_env(
     dataset_id: str,
-    collector_env: Any,
+    collector_env: DataCollectorV0,
     eval_env: Optional[str | gym.Env | EnvSpec] = None,
     algorithm_name: Optional[str] = None,
     author: Optional[str] = None,
@@ -605,30 +606,19 @@ def create_dataset_from_collector_env(
         MinariDataset
     """
     warnings.warn("This function is deprecated and will be removed in v0.5.0. Please use DataCollectorV0.create_dataset() instead.", DeprecationWarning, stacklevel=2)
-    assert collector_env.datasets_path is not None
-    dataset_path = _generate_dataset_path(dataset_id)
-    metadata: Dict[str, Any] = _generate_dataset_metadata(
-        dataset_id,
-        copy.deepcopy(collector_env.env.spec),
-        eval_env,
-        algorithm_name,
-        author,
-        author_email,
-        code_permalink,
-        ref_min_score,
-        ref_max_score,
-        expert_policy,
-        num_episodes_average_score,
-        minari_version,
+    dataset = collector_env.create_dataset(
+        dataset_id=dataset_id,
+        eval_env=eval_env,
+        algorithm_name=algorithm_name,
+        author=author,
+        author_email=author_email,
+        code_permalink=code_permalink,
+        ref_min_score=ref_min_score,
+        ref_max_score=ref_max_score,
+        expert_policy=expert_policy,
+        num_episodes_average_score=num_episodes_average_score,
+        minari_version=minari_version,
     )
-
-    collector_env.save_to_disk(dataset_path, metadata)
-
-    # will be able to calculate dataset size only after saving the disk, so updating the dataset metadata post `save_to_disk` method
-
-    dataset = MinariDataset(dataset_path)
-    metadata['dataset_size'] = dataset.storage.get_size()
-    dataset.storage.update_metadata(metadata)
     return dataset
 
 

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -605,6 +605,7 @@ def create_dataset_from_collector_env(
     Returns:
         MinariDataset
     """
+    warnings.warn("This function is deprecated and will be removed in v0.5.0. Please use env.create_dataset() instead.", DeprecationWarning, stacklevel=2)
     assert collector_env.datasets_path is not None
     dataset_path = _generate_dataset_path(dataset_id)
     metadata: Dict[str, Any] = _generate_dataset_metadata(

--- a/tests/common.py
+++ b/tests/common.py
@@ -583,9 +583,8 @@ def create_dummy_dataset_with_collecter_env_helper(
         env.reset()
 
     # Create Minari dataset and store locally
-    dataset = minari.create_dataset_from_collector_env(
+    dataset = env.create_dataset(
         dataset_id=dataset_id,
-        collector_env=env,
         algorithm_name="random_policy",
         code_permalink="https://github.com/Farama-Foundation/Minari/blob/main/tests/common.py",
         author="WillDudley",

--- a/tests/data_collector/callbacks/test_step_data_callback.py
+++ b/tests/data_collector/callbacks/test_step_data_callback.py
@@ -87,9 +87,8 @@ def test_data_collector_step_data_callback():
         env.reset()
 
     # Create Minari dataset and store locally
-    dataset = minari.create_dataset_from_collector_env(
+    dataset = env.create_dataset(
         dataset_id=dataset_id,
-        collector_env=env,
         algorithm_name="random_policy",
         code_permalink="https://github.com/Farama-Foundation/Minari/blob/f095bfe07f8dc6642082599e07779ec1dd9b2667/tutorials/LocalStorage/local_storage.py",
         author="WillDudley",

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -2,7 +2,6 @@ import gymnasium as gym
 import numpy as np
 import pytest
 
-import minari
 from minari import DataCollectorV0, EpisodeData, MinariDataset, StepDataCallback
 from tests.common import check_load_and_delete_dataset, register_dummy_envs
 
@@ -109,9 +108,8 @@ def test_truncation_without_reset(dataset_id, env_id):
     for _ in range(num_steps):
         env.step(env.action_space.sample())
 
-    dataset = minari.create_dataset_from_collector_env(
+    dataset = env.create_dataset(
         dataset_id=dataset_id,
-        collector_env=env,
         algorithm_name="random_policy",
         author="Farama",
         author_email="farama@farama.org",

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -224,9 +224,8 @@ def test_minari_get_dataset_size_from_collector_env(dataset_id, env_id):
         env.reset()
 
     # Create Minari dataset and store locally
-    dataset = minari.create_dataset_from_collector_env(
+    dataset = env.create_dataset(
         dataset_id=dataset_id,
-        collector_env=env,
         algorithm_name="random_policy",
         code_permalink="https://github.com/Farama-Foundation/Minari/blob/f095bfe07f8dc6642082599e07779ec1dd9b2667/tutorials/LocalStorage/local_storage.py",
         author="WillDudley",

--- a/tests/utils/test_dataset_combine.py
+++ b/tests/utils/test_dataset_combine.py
@@ -94,9 +94,8 @@ def _generate_dataset_with_collector_env(
         env.reset()
 
     # Create Minari dataset and store locally
-    dataset = minari.create_dataset_from_collector_env(
+    dataset = env.create_dataset(
         dataset_id=dataset_id,
-        collector_env=env,
         algorithm_name="random_policy",
         code_permalink="https://github.com/Farama-Foundation/Minari/blob/main/tests/utils/test_dataset_combine.py",
         author="WillDudley",

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -62,10 +62,9 @@ def test_generate_dataset_with_collector_env(dataset_id, env_id):
     if dataset_id in local_datasets:
         minari.delete_dataset(dataset_id)
     # Create Minari dataset and store locally
-    dataset = minari.create_dataset_from_collector_env(
+    dataset = env.create_dataset(
         dataset_id=dataset_id,
         eval_env=eval_env,
-        collector_env=env,
         algorithm_name="random_policy",
         code_permalink=CODELINK,
         author="WillDudley",


### PR DESCRIPTION
# Description

- Move the function `minari.create_dataset_from_collector_env() to env.create_dataset(). Add deprecation warning for the same.
- Add deprecation warning for making env.save_to_disk private.
Both changes planned for release 0.5.0

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Screenshots

N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
