### PR TITLE
Add minari show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ To check available local datasets:
 ```bash
 minari list local
 ```
+To show the details of a dataset:
+
+```bash
+minari show door-human-v1
+```
 
 For the list of commands:
 ```bash

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import importlib.metadata
 import os
+import re
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -18,6 +19,7 @@ from packaging.version import Version
 from minari import DataCollectorV0
 from minari.dataset.minari_dataset import MinariDataset
 from minari.dataset.minari_storage import MinariStorage
+from minari.serialization import deserialize_space
 from minari.storage.datasets_root_dir import get_dataset_path
 
 
@@ -662,3 +664,71 @@ def get_normalized_score(dataset: MinariDataset, returns: np.ndarray) -> np.ndar
         )
 
     return (returns - ref_min_score) / (ref_max_score - ref_min_score)
+
+
+def get_env_spec_dict(env_spec: EnvSpec) -> Dict[str, str]:
+    """Create dict of the environment specs, including observation and action space."""
+    env = gym.make(env_spec.id)
+
+    action_space_table = env.action_space.__repr__().replace("\n", "")
+    observation_space_table = env.observation_space.__repr__().replace("\n", "")
+
+    md_dict = {
+        "ID": env_spec.id,
+        "Observation Space": f"`{re.sub(' +', ' ', observation_space_table)}`",
+        "Action Space": f"`{re.sub(' +', ' ', action_space_table)}`",
+        "entry_point": f"`{env_spec.entry_point}`",
+        "max_episode_steps": env_spec.max_episode_steps,
+        "reward_threshold": env_spec.reward_threshold,
+        "nondeterministic": f"`{env_spec.nondeterministic}`",
+        "order_enforce": f"`{env_spec.order_enforce}`",
+        "autoreset": f"`{env_spec.autoreset}`",
+        "disable_env_checker": f"`{env_spec.disable_env_checker}`",
+        "kwargs": f"`{env_spec.kwargs}`",
+        "additional_wrappers": f"`{env_spec.additional_wrappers}`",
+        "vector_entry_point": f"`{env_spec.vector_entry_point}`",
+    }
+
+    return {k: str(v) for k, v in md_dict.items()}
+
+
+def get_dataset_spec_dict(
+        dataset_spec: Union[Dict[str, Union[str, int, bool]], Dict[str, str]],
+        print_version: bool = False
+) -> Dict[str, str]:
+    """Create dict of the dataset specs, including observation and action space."""
+    code_link = dataset_spec["code_permalink"]
+    action_space = dataset_spec["action_space"]
+    obs_space = dataset_spec["observation_space"]
+
+    assert isinstance(action_space, str)
+    assert isinstance(obs_space, str)
+
+    dataset_action_space = (
+        deserialize_space(action_space).__repr__().replace("\n", "")
+    )
+    dataset_observation_space = (
+        deserialize_space(obs_space)
+        .__repr__()
+        .replace("\n", "")
+    )
+
+    version = str(dataset_spec['minari_version'])
+
+    if print_version:
+        version += f" ({__version__} installed)"
+
+    md_dict = {
+        "Total Timesteps": dataset_spec["total_steps"],
+        "Total Episodes": dataset_spec["total_episodes"],
+        "Dataset Observation Space": f"`{dataset_observation_space}`",
+        "Dataset Action Space": f"`{dataset_action_space}`",
+        "Algorithm": dataset_spec["algorithm_name"],
+        "Author": dataset_spec["author"],
+        "Email": dataset_spec["author_email"],
+        "Code Permalink": f"[{code_link}]({code_link})",
+        "Minari Version": version,
+        "Download": f"`minari.download_dataset(\"{dataset_spec['dataset_id']}\")`"
+    }
+
+    return md_dict


### PR DESCRIPTION
# Description

The existing `minari list` command contains a "Description" column that is currently unused. This PR removes that column and instead creates a command `minari show <dataset_id>` which provides a detailed description of the dataset. See the screenshots below.

There are other small changes to `minari list`. Notably, the Dataset ID column in `minari list` is now a clickable link to the relevant Farama dataset docs page (once the `docs_url` entries have been populated for each dataset).

The layout for `minari show <dataset_id>` closely follows the dataset docs, so some of the functionality in `docs/_scripts/gen_dataset_md.py` has been moved to `minari/utils.py` so that it can be used for the CLI as well.


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Screenshots

**Previous `minari list remote`:**
<img width="930" alt="Screenshot 2023-11-24 at 19 27 51" src="https://github.com/Farama-Foundation/Minari/assets/326411/70273afb-a074-4cf8-8789-29473006a34a">

**Updated `minari list remote`:**
<img width="930" alt="Screenshot 2023-11-24 at 19 35 22" src="https://github.com/Farama-Foundation/Minari/assets/326411/c0ba8ee6-32d8-494f-8f29-5e4443f312c1">

**New command `minari show hammer-cloned-v1`:**
<img width="930" alt="Screenshot 2023-11-24 at 19 36 59" src="https://github.com/Farama-Foundation/Minari/assets/326411/0c98f071-6664-4da6-8726-bb2a33fe4bb6">



# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
