### PR TITLE
DataCollectorV0 -> DataCollector, deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ for episode_data in dataset.iterate_episodes():
 ```python
 import minari
 import gymnasium as gym
-from minari import DataCollectorV0
+from minari import DataCollector
 
 
 env = gym.make('LunarLander-v2')
-env = DataCollectorV0(env)
+env = DataCollector(env)
 
 for _ in range(100):
     env.reset()

--- a/docs/api/data_collector.md
+++ b/docs/api/data_collector.md
@@ -2,7 +2,7 @@
 title: Data Collection
 ---
 
-# DataCollectorV0
+# DataCollector
 
 ```{toctree}
 :hidden:
@@ -10,19 +10,19 @@ data_collector_callbacks/step_data_callback
 data_collector_callbacks/episode_metadata_callback
 ```
 
-## minari.DataCollectorV0
+## minari.DataCollector
 
 ```{eval-rst}
-.. autoclass:: minari.DataCollectorV0
+.. autoclass:: minari.DataCollector
 ```
 
 ### Methods
 
 ```{eval-rst}
-.. autofunction:: minari.DataCollectorV0.step
-.. autofunction:: minari.DataCollectorV0.reset
-.. autofunction:: minari.DataCollectorV0.close
-.. autofunction:: minari.DataCollectorV0.create_dataset
-.. autofunction:: minari.DataCollectorV0.clear_buffer_to_tmp_file
-.. autofunction::minari.DataCollectorV0._add_to_episode_buffer
+.. autofunction:: minari.DataCollector.step
+.. autofunction:: minari.DataCollector.reset
+.. autofunction:: minari.DataCollector.close
+.. autofunction:: minari.DataCollector.create_dataset
+.. autofunction:: minari.DataCollector.clear_buffer_to_tmp_file
+.. autofunction::minari.DataCollector._add_to_episode_buffer
 ```

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -30,29 +30,29 @@ We support Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS.
 ### Collecting Data
 
 ```{eval-rst}
-Minari can abstract the data collection process. This is achieved by using the :class:`minari.DataCollectorV0` wrapper which stores the environments stepping data in internal memory buffers before saving the dataset into disk. The :class:`minari.DataCollectorV0` wrapper can also perform caching by scheduling the amount of episodes or steps that are stored in-memory before saving the data in a temporary `Minari dataset file </content/dataset_standards>`_ . This wrapper also computes relevant metadata of the dataset while collecting the data.
+Minari can abstract the data collection process. This is achieved by using the :class:`minari.DataCollector` wrapper which stores the environments stepping data in internal memory buffers before saving the dataset into disk. The :class:`minari.DataCollector` wrapper can also perform caching by scheduling the amount of episodes or steps that are stored in-memory before saving the data in a temporary `Minari dataset file </content/dataset_standards>`_ . This wrapper also computes relevant metadata of the dataset while collecting the data.
 
 The wrapper is very simple to initialize:
 ```
 
 ```python
-from minari import DataCollectorV0
+from minari import DataCollector
 import gymnasium as gym
 
 env = gym.make('CartPole-v1')
-env = DataCollectorV0(env, record_infos=True, max_buffer_steps=100000)
+env = DataCollector(env, record_infos=True, max_buffer_steps=100000)
 ```
 
 ```{eval-rst}
-In this example, the :class:`minari.DataCollectorV0` wraps the `'CartPole-v1'` environment from Gymnasium. The arguments passed are ``record_infos`` (when set to ``True`` the wrapper will also collect the returned ``info`` dictionaries to create the dataset), and the ``max_buffer_steps`` argument, which specifies a caching scheduler by giving the number of data steps to store in-memory before moving them to a temporary file on disk. There are more arguments that can be passed to this wrapper, a detailed description of them can be read in the :class:`minari.DataCollectorV0` documentation.
+In this example, the :class:`minari.DataCollector` wraps the `'CartPole-v1'` environment from Gymnasium. The arguments passed are ``record_infos`` (when set to ``True`` the wrapper will also collect the returned ``info`` dictionaries to create the dataset), and the ``max_buffer_steps`` argument, which specifies a caching scheduler by giving the number of data steps to store in-memory before moving them to a temporary file on disk. There are more arguments that can be passed to this wrapper, a detailed description of them can be read in the :class:`minari.DataCollector` documentation.
 ```
 
 ### Save Dataset
 
 ```{eval-rst}
-To create a Minari dataset first we need to step the environment with a given policy to allow the :class:`minari.DataCollectorV0` to record the data that will comprise the dataset. This is as simple as just looping through the Gymansium MDP API. For our example we will loop through ``100`` episodes of the ``'CartPole-v1'`` environment with a random policy.
+To create a Minari dataset first we need to step the environment with a given policy to allow the :class:`minari.DataCollector` to record the data that will comprise the dataset. This is as simple as just looping through the Gymansium MDP API. For our example we will loop through ``100`` episodes of the ``'CartPole-v1'`` environment with a random policy.
 
-Finally, we need to create the Minari dataset and give it a name id. This is done by calling the :func:`DataCollectorV0.create_dataset` Minari function which will move the temporary data recorded in the :class:`minari.DataCollectorV0` environment to a permanent location in the `local Minari root path </content/dataset_standards>`_ with the Minari dataset standard structure.
+Finally, we need to create the Minari dataset and give it a name id. This is done by calling the :func:`DataCollector.create_dataset` Minari function which will move the temporary data recorded in the :class:`minari.DataCollector` environment to a permanent location in the `local Minari root path </content/dataset_standards>`_ with the Minari dataset standard structure.
 
 Extending the code example for the ``'CartPole-v1'`` environment we can create the Minari dataset as follows:
 ```
@@ -60,10 +60,10 @@ Extending the code example for the ``'CartPole-v1'`` environment we can create t
 ```python
 import minari
 import gymnasium as gym
-from minari import DataCollectorV0
+from minari import DataCollector
 
 env = gym.make('CartPole-v1')
-env = DataCollectorV0(env, record_infos=True, max_buffer_steps=100000)
+env = DataCollector(env, record_infos=True, max_buffer_steps=100000)
 
 total_episodes = 100
 
@@ -87,7 +87,7 @@ dataset = env.create_dataset(dataset_id="CartPole-v1-test-v0",
 ```{eval-rst}
 When creating the Minari dataset additional metadata can be added such as the ``algorithm_name`` used to compute the actions, a ``code_permalink`` with a link to the code used to generate the dataset, as well as the ``author`` and ``author_email``.
 
-The :func:`DataCollectorV0.create_dataset` function returns a :class:`minari.MinariDataset` object, ``dataset`` in the previous code snippet.
+The :func:`DataCollector.create_dataset` function returns a :class:`minari.MinariDataset` object, ``dataset`` in the previous code snippet.
 
 Once the dataset has been created we can check if the Minari dataset id appears in the list of local datasets:
 ```
@@ -102,16 +102,16 @@ dict_keys(['CartPole-v1-test-v0'])
 ```{eval-rst}
 The :func:`minari.list_local_datasets` function returns a dictionary with keys the local Minari dataset ids and values their metadata.
 
-There is another optional way of creating a Minari dataset and that is by using the :func:`minari.create_dataset_from_buffers` function. The data collection is left to the user instead of using the :class:`minari.DataCollectorV0` wrapper. The user will be responsible for creating their own buffers to store the stepping data, and these buffers must follow a specific structure specified in the function API documentation.
+There is another optional way of creating a Minari dataset and that is by using the :func:`minari.create_dataset_from_buffers` function. The data collection is left to the user instead of using the :class:`minari.DataCollector` wrapper. The user will be responsible for creating their own buffers to store the stepping data, and these buffers must follow a specific structure specified in the function API documentation.
 ```
 
 ### Checkpoint Minari Dataset
 
 ```{eval-rst}
-When collecting data with the :class:`minari.DataCollectorV0` wrapper, the recorded data is saved into temporary files and it won't be permanently saved in disk until the :func:`DataCollectorV0.create_dataset` function is called. For large datasets, to avoid losing all of the collected data, extra data from a :class:`minari.DataCollectorV0` can be appended to checkpoint the data collection process.
+When collecting data with the :class:`minari.DataCollector` wrapper, the recorded data is saved into temporary files and it won't be permanently saved in disk until the :func:`DataCollector.create_dataset` function is called. For large datasets, to avoid losing all of the collected data, extra data from a :class:`minari.DataCollector` can be appended to checkpoint the data collection process.
 
 
-To checkpoint a dataset we can call the :func:`minari.MinariDataset.update_dataset_from_collector_env` method. Every time the function :func:`DataCollectorV0.create_dataset` or the method :func:`minari.MinariDataset.update_dataset_from_collector_env` are called, the buffers from the :class:`minari.DataCollectorV0` environment are cleared.
+To checkpoint a dataset we can call the :func:`minari.MinariDataset.update_dataset_from_collector_env` method. Every time the function :func:`DataCollector.create_dataset` or the method :func:`minari.MinariDataset.update_dataset_from_collector_env` are called, the buffers from the :class:`minari.DataCollector` environment are cleared.
 
 Continuing the ``'CartPole-v1'`` example we can checkpoint the newly created Minari dataset every 10 episodes as follows:
 ```
@@ -119,10 +119,10 @@ Continuing the ``'CartPole-v1'`` example we can checkpoint the newly created Min
 ```python
 import minari
 import gymnasium as gym
-from minari import DataCollectorV0
+from minari import DataCollector
 
 env = gym.make('CartPole-v1')
-env = DataCollectorV0(env, record_infos=True, max_buffer_steps=100000)
+env = DataCollector(env, record_infos=True, max_buffer_steps=100000)
 
 total_episodes = 100
 dataset_name = "CartPole-v1-test-v0"

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -410,7 +410,7 @@ The required `datasets` found in the episode groups correspond to the data invol
 
 The `dtype` of the numpy array datasets can be of any type compatible with [`h5py`](https://docs.h5py.org/en/latest/faq.html#what-datatypes-are-supported).
 
-The `info` dictionary returned in `env.step()` and `env.reset()` can be optionally saved in the dataset as a `sub-group`. The option to save the `info` data can be set in the `DataCollectorv0` wrapper with the  `record_infos` argument.
+The `info` dictionary returned in `env.step()` and `env.reset()` can be optionally saved in the dataset as a `sub-group`. The option to save the `info` data can be set in the `DataCollector` wrapper with the  `record_infos` argument.
 
 Also, additional `datasets` and nested `sub-groups` can be saved in each episode. This can be the case of environment data that doesn't participate in each `env.step()` or `env.reset()` call in the Gymnasium API, such as the full environment state in each step. This can be achieved by creating a custom `StepDataCallback` that returns extra keys and nested dictionaries in the `StepData` dictionary return.
 
@@ -472,9 +472,9 @@ The episode groups in the `HDF5` file will then have the following structure:
 </div>
 
 ### Default dataset metadata
-`HDF5` files can have metadata attached to `objects` as [`attributes`](https://docs.h5py.org/en/stable/high/attr.html). Minari uses these `attributes` to add metadata to the global dataset file, to each episode group, as well as to the individual datasets inside each episode. This                                                                                 metadata can be added by the user by overriding the `EpisodeMetadataCallback` in the `DataCollectorV0` wrapper. However, there is also some metadata added by default to every dataset.
+`HDF5` files can have metadata attached to `objects` as [`attributes`](https://docs.h5py.org/en/stable/high/attr.html). Minari uses these `attributes` to add metadata to the global dataset file, to each episode group, as well as to the individual datasets inside each episode. This                                                                                 metadata can be added by the user by overriding the `EpisodeMetadataCallback` in the `DataCollector` wrapper. However, there is also some metadata added by default to every dataset.
 
-When creating a Minari dataset with the `DataCollectorV0` wrapper the default global metadata will be the following:
+When creating a Minari dataset with the `DataCollector` wrapper the default global metadata will be the following:
 
 | Attribute               | Type       | Description |
 | ----------------------- | ---------- | ----------- |

--- a/docs/tutorials/dataset_creation/custom_space_serialization.py
+++ b/docs/tutorials/dataset_creation/custom_space_serialization.py
@@ -5,7 +5,7 @@ Serializing a custom space
 """
 # %%%
 # In this tutorial you'll learn how to serialize a custom Gymnasium observation space and use that
-# to create a Minari dataset with :class:`minari.DataCollectorV0`. We'll use the
+# to create a Minari dataset with :class:`minari.DataCollector`. We'll use the
 # `MiniGrid Empty <https://minigrid.farama.org/environments/minigrid/EmptyEnv/>`_ environment and
 # show how to serialize its unique observation space.
 #
@@ -26,7 +26,7 @@ import gymnasium as gym
 from minigrid.core.mission import MissionSpace
 
 import minari
-from minari import DataCollectorV0
+from minari import DataCollector
 from minari.serialization import deserialize_space, serialize_space
 
 
@@ -110,7 +110,7 @@ def deserialize_custom_space(space_dict: Dict) -> MissionSpace:
 
 dataset_id = "minigrid-custom-space-v0"
 
-env = DataCollectorV0(env)
+env = DataCollector(env)
 num_episodes = 10
 
 env.reset(seed=42)

--- a/docs/tutorials/dataset_creation/observation_space_subseting.py
+++ b/docs/tutorials/dataset_creation/observation_space_subseting.py
@@ -4,7 +4,7 @@ Collecting a subset of a dictionary space with StepDataCallback
 =========================================
 """
 # %%%
-# In this tutorial you'll learn how to have :class:`minari.DataCollectorV0` only collect a subset
+# In this tutorial you'll learn how to have :class:`minari.DataCollector` only collect a subset
 # of the observation space in PointMaze. Specifically, we'll be collecting observations using
 # random actions on PointMaze_UMaze-v3 from `Gymnasium-Robotics <https://robotics.farama.org/envs/maze/point_maze/>`_
 # and omitting ``achieved_goal`` from the observation space of PointMaze.
@@ -24,7 +24,7 @@ import numpy as np
 from gymnasium import spaces
 
 import minari
-from minari import DataCollectorV0
+from minari import DataCollector
 from minari.data_collector.callbacks import StepDataCallback
 
 
@@ -72,7 +72,7 @@ class CustomSubsetStepDataCallback(StepDataCallback):
 
 # %%
 # Finally we'll record 10 episodes with our observation space subset and
-# callback passed to :class:`minari.DataCollectorV0`.
+# callback passed to :class:`minari.DataCollector`.
 
 dataset_id = "point-maze-subseted-v3"
 
@@ -81,7 +81,7 @@ local_datasets = minari.list_local_datasets()
 if dataset_id in local_datasets:
     minari.delete_dataset(dataset_id)
 
-env = DataCollectorV0(
+env = DataCollector(
     env,
     observation_space=observation_space_subset,
     # action_space=action_space_subset,

--- a/docs/tutorials/dataset_creation/point_maze_dataset.py
+++ b/docs/tutorials/dataset_creation/point_maze_dataset.py
@@ -11,7 +11,7 @@ PointMaze D4RL dataset
 #   1. First we need to create a planner that outputs a trajectory of waypoints that the agent can follow to reach the goal from its initial location in the maze. We will be using
 #      `Q-Value Iteration <https://towardsdatascience.com/fundamental-iterative-methods-of-reinforcement-learning-df8ff078652a>`_ [2] to solve the discrete grid maze, same as in D4RL.
 #   2. Then we also need to generate the actions so that the agent can follow the waypoints of the trajectory. For this purpose D4RL implements a PD controller.
-#   3. Finally, to create the Minari dataset, we will wrap the environment with a :class:`minari.DataCollectorV0` and step through it by generating actions with the path planner and waypoint controller.
+#   3. Finally, to create the Minari dataset, we will wrap the environment with a :class:`minari.DataCollector` and step through it by generating actions with the path planner and waypoint controller.
 #
 # For this tutorial we will be using the ``pointmaze-medium-v3`` environment to collect transition data. However, any map implementation in the PointMaze environment group can be used.
 # Another important factor to take into account is that the environment is continuing, which means that it won't be ``terminated`` when reaching a goal. Instead a new goal target will be randomly selected and the agent
@@ -22,7 +22,7 @@ PointMaze D4RL dataset
 import gymnasium as gym
 import numpy as np
 
-from minari import DataCollectorV0, StepDataCallback
+from minari import DataCollector, StepDataCallback
 
 
 # %%
@@ -359,7 +359,7 @@ class PointMazeStepDataCallback(StepDataCallback):
 # Collect Data and Create Minari Dataset
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Now we will finally perform our data collection and create the Minari dataset. This is as simple as wrapping the environment with
-# the :class:`minari.DataCollectorV0` wrapper and add the custom callback methods. Once we've done this we can step the environment with the ``WayPointController``
+# the :class:`minari.DataCollector` wrapper and add the custom callback methods. Once we've done this we can step the environment with the ``WayPointController``
 # as our policy. For the tutorial, we collect 10,000 transitions. Thus, we initialize the environment with ``max_episode_steps=10,000`` since that's the total amount of steps we want to
 # collect for our dataset and we don't want the environment to get ``truncated`` during the data collection due to a time limit.
 #
@@ -377,7 +377,7 @@ env = gym.make("PointMaze_Medium-v3", continuing_task=True, max_episode_steps=to
 #   * Custom StepDataCallback to add extra state information to 'infos' and divide dataset in different episodes by overridng
 #     truncation value to True when target is reached
 #   * Record the 'info' value of every step
-collector_env = DataCollectorV0(
+collector_env = DataCollector(
     env, step_data_callback=PointMazeStepDataCallback, record_infos=True
 )
 

--- a/docs/tutorials/using_datasets/behavioral_cloning.py
+++ b/docs/tutorials/using_datasets/behavioral_cloning.py
@@ -28,7 +28,7 @@ from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 
 import minari
-from minari import DataCollectorV0
+from minari import DataCollector
 
 
 torch.manual_seed(42)
@@ -49,10 +49,10 @@ train()
 # %%
 # Dataset generation
 # ~~~~~~~~~~~~~~~~~~~
-# Now let's generate the dataset using the `DataCollectorV0 <https://minari.farama.org/api/data_collector/>`_ wrapper:
+# Now let's generate the dataset using the `DataCollector <https://minari.farama.org/api/data_collector/>`_ wrapper:
 #
 
-env = DataCollectorV0(gym.make('CartPole-v1'))
+env = DataCollector(gym.make('CartPole-v1'))
 path = os.path.abspath('') + '/logs/ppo/CartPole-v1_1/best_model'
 agent = PPO.load(path)
 

--- a/minari/__init__.py
+++ b/minari/__init__.py
@@ -45,4 +45,3 @@ def __getattr__(name):
     if name == "DataCollectorV0":
         from minari.data_collector import DataCollectorV0
         return DataCollectorV0
-

--- a/minari/__init__.py
+++ b/minari/__init__.py
@@ -1,4 +1,4 @@
-from minari.data_collector import DataCollectorV0
+from minari.data_collector import DataCollector
 from minari.data_collector.callbacks import EpisodeMetadataCallback, StepDataCallback
 from minari.dataset.minari_dataset import EpisodeData, MinariDataset
 from minari.storage.hosting import (
@@ -21,7 +21,7 @@ __all__ = [
     "MinariDataset",
     "EpisodeData",
     # Data collection
-    "DataCollectorV0",
+    "DataCollector",
     "EpisodeMetadataCallback",
     "StepDataCallback",
     # Dataset Functions
@@ -39,3 +39,10 @@ __all__ = [
 ]
 
 __version__ = "0.4.2"
+
+
+def __getattr__(name):
+    if name == "DataCollectorV0":
+        from minari.data_collector import DataCollectorV0
+        return DataCollectorV0
+

--- a/minari/data_collector/__init__.py
+++ b/minari/data_collector/__init__.py
@@ -1,1 +1,10 @@
-from minari.data_collector.data_collector import DataCollectorV0
+from minari.data_collector.data_collector import DataCollector
+
+
+__all__ = ["DataCollector"]
+
+
+def __getattr__(name):
+    if name == "DataCollectorV0":
+        from minari.data_collector.data_collector import DataCollectorV0
+        return DataCollectorV0

--- a/minari/data_collector/callbacks/episode_metadata.py
+++ b/minari/data_collector/callbacks/episode_metadata.py
@@ -8,7 +8,7 @@ class EpisodeMetadataCallback:
 
     This callback can be overridden to add extra metadata attributes or statistics to
     each episode in the Minari dataset. The custom callback can then be
-    passed to the DataCollectorV0 wrapper to the `episode_metadata_callback` argument.
+    passed to the DataCollector wrapper to the `episode_metadata_callback` argument.
 
     TODO: add more default statistics to episode datasets
     """

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -31,6 +31,7 @@ class DataCollectorV0:
     def __new__(cls, *args, **kwargs):
         return DataCollector(*args, **kwargs)
 
+
 class DataCollector(gym.Wrapper):
     r"""Gymnasium environment wrapper that collects step data.
 

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -30,7 +30,7 @@ class DataCollectorV0:
 
     def __new__(cls, *args, **kwargs):
         return DataCollector(*args, **kwargs)
-    
+
 class DataCollector(gym.Wrapper):
     r"""Gymnasium environment wrapper that collects step data.
 

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -25,7 +25,13 @@ from minari.dataset.minari_storage import MinariStorage
 EpisodeBuffer = Dict[str, Any]  # TODO: narrow this down
 
 
-class DataCollectorV0(gym.Wrapper):
+class DataCollectorV0:
+    warnings.warn("DataCollectorV0 is deprecated and will be removed. Use DataCollector instead.", DeprecationWarning, stacklevel=5)
+
+    def __new__(cls, *args, **kwargs):
+        return DataCollector(*args, **kwargs)
+    
+class DataCollector(gym.Wrapper):
     r"""Gymnasium environment wrapper that collects step data.
 
     This wrapper is meant to work as a temporary buffer of the environment data before creating a Minari dataset. The creation of the buffers
@@ -36,7 +42,7 @@ class DataCollectorV0(gym.Wrapper):
         import minari
         import gymnasium as gym
 
-        env = minari.DataCollectorV0(gym.make('EnvID'))
+        env = minari.DataCollector(gym.make('EnvID'))
 
         env.reset()
 
@@ -62,7 +68,7 @@ class DataCollectorV0(gym.Wrapper):
 
         * To perform caching the user can set the `max_buffer_steps` or `max_buffer_episodes` before saving the in-memory buffers to a temporary HDF5
           file in disk. If non of `max_buffer_steps` or `max_buffer_episodes` are set, the data will move from in-memory to a permanent location only
-          when the Minari dataset is created. To move all the stored data to a permanent location use DataCollectorV0.save_to_disK(path_to_permanent_location).
+          when the Minari dataset is created. To move all the stored data to a permanent location use DataCollector.save_to_disK(path_to_permanent_location).
     """
 
     def __init__(
@@ -238,7 +244,7 @@ class DataCollectorV0(gym.Wrapper):
                 self._buffer[-1]["truncations"][-1] = True
 
     def add_to_dataset(self, dataset: MinariDataset):
-        """Add extra data to Minari dataset from collector environment buffers (DataCollectorV0).
+        """Add extra data to Minari dataset from collector environment buffers (DataCollector).
 
         Args:
             dataset (MinariDataset): Dataset to add the data
@@ -276,7 +282,7 @@ class DataCollectorV0(gym.Wrapper):
         num_episodes_average_score: int = 100,
         minari_version: Optional[str] = None,
     ):
-        """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollectorV0` Minari wrapper.
+        """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollector` Minari wrapper.
 
         The ``dataset_id`` parameter corresponds to the name of the dataset, with the syntax as follows:
         ``(env_name-)(dataset_name)(-v(version))`` where ``env_name`` identifies the name of the environment used to generate the dataset ``dataset_name``.

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -16,7 +16,7 @@ from gymnasium.wrappers.record_episode_statistics import RecordEpisodeStatistics
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
 
-from minari import DataCollectorV0
+from minari import DataCollector
 from minari.dataset.minari_dataset import MinariDataset
 from minari.dataset.minari_storage import MinariStorage
 from minari.serialization import deserialize_space
@@ -569,7 +569,7 @@ def create_dataset_from_buffers(
 
 def create_dataset_from_collector_env(
     dataset_id: str,
-    collector_env: DataCollectorV0,
+    collector_env: DataCollector,
     eval_env: Optional[str | gym.Env | EnvSpec] = None,
     algorithm_name: Optional[str] = None,
     author: Optional[str] = None,
@@ -581,7 +581,7 @@ def create_dataset_from_collector_env(
     num_episodes_average_score: int = 100,
     minari_version: Optional[str] = None,
 ):
-    """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollectorV0` Minari wrapper.
+    """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollector` Minari wrapper.
 
     The ``dataset_id`` parameter corresponds to the name of the dataset, with the syntax as follows:
     ``(env_name-)(dataset_name)(-v(version))`` where ``env_name`` identifies the name of the environment used to generate the dataset ``dataset_name``.
@@ -589,7 +589,7 @@ def create_dataset_from_collector_env(
 
     Args:
         dataset_id (str): name id to identify Minari dataset
-        collector_env (DataCollectorV0): Gymnasium environment used to collect the buffer data
+        collector_env (DataCollector): Gymnasium environment used to collect the buffer data
         buffer (list[Dict[str, Union[list, Dict]]]): list of episode dictionaries with data
         eval_env (Optional[str|gym.Env|EnvSpec]): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) to use for evaluation with the dataset. After loading the dataset, the environment can be recovered as follows: `MinariDataset.recover_environment(eval_env=True).
                                                 If None the `env` used to collect the buffer data should be used for evaluation.
@@ -607,7 +607,7 @@ def create_dataset_from_collector_env(
     Returns:
         MinariDataset
     """
-    warnings.warn("This function is deprecated and will be removed in v0.5.0. Please use DataCollectorV0.create_dataset() instead.", DeprecationWarning, stacklevel=2)
+    warnings.warn("This function is deprecated and will be removed in v0.5.0. Please use DataCollector.create_dataset() instead.", DeprecationWarning, stacklevel=2)
     dataset = collector_env.create_dataset(
         dataset_id=dataset_id,
         eval_env=eval_env,

--- a/test.py
+++ b/test.py
@@ -1,1 +1,0 @@
-from minari import DataCollectorV0

--- a/test.py
+++ b/test.py
@@ -1,0 +1,1 @@
+from minari import DataCollectorV0

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,7 +11,7 @@ from gymnasium.envs.registration import register
 from gymnasium.utils.env_checker import data_equivalence
 
 import minari
-from minari import DataCollectorV0, MinariDataset
+from minari import DataCollector, MinariDataset
 from minari.dataset.minari_dataset import EpisodeData
 from minari.dataset.minari_storage import MinariStorage
 
@@ -564,13 +564,13 @@ def check_load_and_delete_dataset(dataset_id: str):
 
 
 def create_dummy_dataset_with_collecter_env_helper(
-    dataset_id: str, env: DataCollectorV0, num_episodes: int = 10, **kwargs
+    dataset_id: str, env: DataCollector, num_episodes: int = 10, **kwargs
 ):
     local_datasets = minari.list_local_datasets()
     if dataset_id in local_datasets:
         minari.delete_dataset(dataset_id)
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 
     for episode in range(num_episodes):
@@ -652,7 +652,7 @@ def get_sample_buffer_for_dataset_from_env(env, num_episodes=10):
 
     observation, info = env.reset(seed=42)
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     observation, _ = env.reset()
     observations.append(_space_subset_helper(observation))
     for episode in range(num_episodes):

--- a/tests/data_collector/callbacks/test_step_data_callback.py
+++ b/tests/data_collector/callbacks/test_step_data_callback.py
@@ -3,7 +3,7 @@ import numpy as np
 from gymnasium import spaces
 
 import minari
-from minari import DataCollectorV0, MinariDataset
+from minari import DataCollector, MinariDataset
 from minari.data_collector.callbacks import StepDataCallback
 from tests.common import (
     check_data_integrity,
@@ -38,7 +38,7 @@ class CustomSubsetStepDataCallback(StepDataCallback):
 
 
 def test_data_collector_step_data_callback():
-    """Test DataCollectorV0 wrapper and Minari dataset creation."""
+    """Test DataCollector wrapper and Minari dataset creation."""
     dataset_id = "dummy-dict-test-v0"
     # delete the test dataset if it already exists
     local_datasets = minari.list_local_datasets()
@@ -66,7 +66,7 @@ def test_data_collector_step_data_callback():
         }
     )
 
-    env = DataCollectorV0(
+    env = DataCollector(
         env,
         observation_space=observation_space_subset,
         action_space=action_space_subset,
@@ -74,7 +74,7 @@ def test_data_collector_step_data_callback():
     )
     num_episodes = 10
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 
     for episode in range(num_episodes):

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -2,7 +2,7 @@ import gymnasium as gym
 import numpy as np
 import pytest
 
-from minari import DataCollectorV0, EpisodeData, MinariDataset, StepDataCallback
+from minari import DataCollector, EpisodeData, MinariDataset, StepDataCallback
 from tests.common import check_load_and_delete_dataset, register_dummy_envs
 
 
@@ -98,7 +98,7 @@ def test_truncation_without_reset(dataset_id, env_id):
     num_steps = 50
     num_episodes = int(num_steps / ForceTruncateStepDataCallback.episode_steps)
     env = gym.make(env_id, max_episode_steps=50)
-    env = DataCollectorV0(
+    env = DataCollector(
         env,
         step_data_callback=ForceTruncateStepDataCallback,
     )

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -10,7 +10,7 @@ import pytest
 from gymnasium.envs.registration import EnvSpec
 
 import minari
-from minari import DataCollectorV0, MinariDataset
+from minari import DataCollector, MinariDataset
 from minari.dataset.minari_dataset import EpisodeData
 from minari.dataset.minari_storage import MinariStorage
 from tests.common import (
@@ -78,14 +78,14 @@ def test_update_dataset_from_collector_env(dataset_id, env_id):
 
     env = gym.make(env_id)
 
-    env = DataCollectorV0(env)
+    env = DataCollector(env)
     num_episodes = 10
 
     dataset = create_dummy_dataset_with_collecter_env_helper(
         dataset_id, env, num_episodes=num_episodes
     )
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 
     for episode in range(num_episodes):
@@ -133,7 +133,7 @@ def test_filter_episodes_and_subsequent_updates(dataset_id, env_id):
 
     env = gym.make(env_id)
 
-    env = DataCollectorV0(env)
+    env = DataCollector(env)
     num_episodes = 10
 
     dataset = create_dummy_dataset_with_collecter_env_helper(
@@ -155,7 +155,7 @@ def test_filter_episodes_and_subsequent_updates(dataset_id, env_id):
     )  # checks that the underlying episodes are still present in the `MinariStorage` object
     check_env_recovery(env.env, filtered_dataset)
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 
     for episode in range(num_episodes):
@@ -306,7 +306,7 @@ def test_sample_episodes(dataset_id, env_id):
 
     env = gym.make(env_id)
 
-    env = DataCollectorV0(env)
+    env = DataCollector(env)
     num_episodes = 10
 
     dataset = create_dummy_dataset_with_collecter_env_helper(
@@ -349,7 +349,7 @@ def test_iterate_episodes(dataset_id, env_id):
 
     env = gym.make(env_id)
 
-    env = DataCollectorV0(env)
+    env = DataCollector(env)
     num_episodes = 10
 
     dataset = create_dummy_dataset_with_collecter_env_helper(
@@ -398,7 +398,7 @@ def test_update_dataset_from_buffer(dataset_id, env_id):
 
     env = gym.make(env_id)
 
-    collector_env = DataCollectorV0(env)
+    collector_env = DataCollector(env)
     num_episodes = 10
 
     dataset = create_dummy_dataset_with_collecter_env_helper(

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -7,7 +7,7 @@ import pytest
 from gymnasium import spaces
 
 import minari
-from minari import DataCollectorV0
+from minari import DataCollector
 from minari.dataset.minari_storage import MinariStorage
 from tests.common import (
     check_data_integrity,
@@ -208,10 +208,10 @@ def test_minari_get_dataset_size_from_collector_env(dataset_id, env_id):
 
     env = gym.make(env_id)
 
-    env = DataCollectorV0(env)
+    env = DataCollector(env)
     num_episodes = 100
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 
     for episode in range(num_episodes):
@@ -274,7 +274,7 @@ def test_minari_get_dataset_size_from_buffer(dataset_id, env_id):
 
     observation, info = env.reset(seed=42)
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     observation, _ = env.reset()
     observations.append(observation)
     for episode in range(num_episodes):

--- a/tests/utils/test_dataset_combine.py
+++ b/tests/utils/test_dataset_combine.py
@@ -8,7 +8,7 @@ from gymnasium.utils.env_checker import data_equivalence
 from packaging.specifiers import SpecifierSet
 
 import minari
-from minari import DataCollectorV0, MinariDataset
+from minari import DataCollector, MinariDataset
 from minari.utils import combine_datasets, combine_minari_version_specifiers
 from tests.common import get_sample_buffer_for_dataset_from_env
 
@@ -80,8 +80,8 @@ def _generate_dataset_with_collector_env(
     else:
         env = gym.make("CartPole-v1", max_episode_steps=max_episode_steps)
 
-    env = DataCollectorV0(env)
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    env = DataCollector(env)
+    # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 
     for episode in range(num_episodes):

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -6,7 +6,7 @@ import pytest
 from gymnasium import spaces
 
 import minari
-from minari import DataCollectorV0, MinariDataset
+from minari import DataCollector, MinariDataset
 from tests.common import (
     check_data_integrity,
     check_env_recovery,
@@ -34,13 +34,13 @@ register_dummy_envs()
     ],
 )
 def test_generate_dataset_with_collector_env(dataset_id, env_id):
-    """Test DataCollectorV0 wrapper and Minari dataset creation."""
+    """Test DataCollector wrapper and Minari dataset creation."""
     env = gym.make(env_id)
 
-    env = DataCollectorV0(env)
+    env = DataCollector(env)
     num_episodes = 10
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 
     for episode in range(num_episodes):
@@ -105,7 +105,7 @@ def test_generate_dataset_with_collector_env(dataset_id, env_id):
     ],
 )
 def test_generate_dataset_with_external_buffer(dataset_id, env_id):
-    """Test create dataset from external buffers without using DataCollectorV0."""
+    """Test create dataset from external buffers without using DataCollector."""
     buffer = []
 
     # dataset_id = "cartpole-test-v0"
@@ -126,7 +126,7 @@ def test_generate_dataset_with_external_buffer(dataset_id, env_id):
 
     observation, info = env.reset(seed=42)
 
-    # Step the environment, DataCollectorV0 wrapper will do the data collection job
+    # Step the environment, DataCollector wrapper will do the data collection job
     observation, _ = env.reset()
     observations.append(observation)
     for episode in range(num_episodes):
@@ -196,7 +196,7 @@ def test_generate_dataset_with_external_buffer(dataset_id, env_id):
 
 @pytest.mark.parametrize("is_env_needed", [True, False])
 def test_generate_dataset_with_space_subset_external_buffer(is_env_needed):
-    """Test create dataset from external buffers without using DataCollectorV0 or environment."""
+    """Test create dataset from external buffers without using DataCollector or environment."""
     dataset_id = "dummy-dict-test-v0"
 
     # delete the test dataset if it already exists

--- a/tests/utils/test_get_normalized_score.py
+++ b/tests/utils/test_get_normalized_score.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import minari
 from minari import get_normalized_score
-from minari.data_collector.data_collector import DataCollectorV0
+from minari.data_collector.data_collector import DataCollector
 from tests.common import create_dummy_dataset_with_collecter_env_helper
 
 
@@ -14,7 +14,7 @@ def test_ref_score():
 
     env = gym.make("CartPole-v1")
 
-    env = DataCollectorV0(env)
+    env = DataCollector(env)
     num_episodes = 10
 
     ref_min_score, ref_max_score = -1, 100


### PR DESCRIPTION
# Description

Add deprecation warning to DataCollectorV0 ad we are dropping the versioning following Gymnasium.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
