### PR TITLE
Add automatic seeding of Datacollector reset

### DIFF
--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -205,10 +205,14 @@ class MinariStorage:
                 ep_group = file[f"episode_{ep_idx}"]
                 assert isinstance(ep_group, h5py.Group)
 
+                seed = ep_group.attrs.get("seed")
+                if isinstance(seed, np.integer):
+                    seed = int(seed)
+
                 ep_dict = {
                     "id": ep_group.attrs.get("id"),
                     "total_timesteps": ep_group.attrs.get("total_steps"),
-                    "seed": ep_group.attrs.get("seed"),
+                    "seed": seed,
                     "observations": self._decode_space(
                         ep_group["observations"], self.observation_space
                     ),

--- a/tests/common.py
+++ b/tests/common.py
@@ -36,6 +36,7 @@ class DummyBoxEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         self.timestep = 0
+        self.observation_space.seed(seed)
         return self.observation_space.sample(), {}
 
 
@@ -56,6 +57,7 @@ class DummyMultiDimensionalBoxEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         self.timestep = 0
+        self.observation_space.seed(seed)
         return self.observation_space.sample(), {}
 
 
@@ -82,6 +84,7 @@ class DummyTupleDiscreteBoxEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         self.timestep = 0
+        self.observation_space.seed(seed)
         return self.observation_space.sample(), {}
 
 
@@ -118,6 +121,7 @@ class DummyDictEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         self.timestep = 0
+        self.observation_space.seed(seed)
         return self.observation_space.sample(), {}
 
 
@@ -150,6 +154,7 @@ class DummyTupleEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         self.timestep = 0
+        self.observation_space.seed(seed)
         return self.observation_space.sample(), {}
 
 
@@ -166,6 +171,7 @@ class DummyTextEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         self.timestep = 0
+        self.observation_space.seed(seed)
         return "者示序袋費欠走立🐝🗓🈸🐿🍯🚆▶️🎧🎇💫", {}
 
 
@@ -219,6 +225,7 @@ class DummyComboEnv(gym.Env):
 
     def reset(self, seed=0, options=None):
         self.timestep = 0
+        self.observation_space.seed(seed)
         return self.observation_space.sample(), {}
 
 

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -6,6 +6,8 @@ from minari import DataCollector, EpisodeData, MinariDataset, StepDataCallback
 from tests.common import check_load_and_delete_dataset, register_dummy_envs
 
 
+MAX_UINT64 = np.iinfo(np.uint64).max
+
 register_dummy_envs()
 
 
@@ -140,4 +142,49 @@ def test_truncation_without_reset(dataset_id, env_id):
         assert bool(last_step.truncations) is True
 
     # check load and delete local dataset
+    check_load_and_delete_dataset(dataset_id)
+
+
+@pytest.mark.parametrize("seed", [None, 0, 42, MAX_UINT64])
+def test_reproducibility(seed):
+    """Test episodes are reproducible, even if an explicit reset seed is not set."""
+    dataset_id = "dummy-box-test-v0"
+    env_id = "DummyBoxEnv-v0"
+    policy_seed = 42
+    num_episodes = 5
+
+    env = DataCollector(gym.make(env_id))
+
+    for _ in range(num_episodes):
+        env.reset(seed=seed)
+        env.action_space.seed(policy_seed)
+
+        trunc = False
+        term = False
+
+        while not (trunc or term):
+            _, _, trunc, term, _ = env.step(env.action_space.sample())
+
+    dataset = env.create_dataset(dataset_id)
+    env.close()
+
+    # Step through the env again using the stored seed and check it matches
+    env = dataset.recover_environment()
+
+    for episode in dataset.sample_episodes(dataset.total_episodes):
+        if seed is None:
+            assert isinstance(episode.seed, int)
+        else:
+            assert seed == episode.seed
+
+        obs, _ = env.reset(seed=episode.seed)
+        env.action_space.seed(policy_seed)
+
+        assert np.allclose(obs, episode.observations[0])
+
+        for k in range(episode.total_timesteps):
+            obs, rew, trunc, _, _ = env.step(env.action_space.sample())
+            assert np.allclose(obs, episode.observations[k + 1])
+            assert rew == episode.rewards[k]
+
     check_load_and_delete_dataset(dataset_id)

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -189,7 +189,7 @@ def test_reproducibility(seed):
             obs, rew, term, trunc, _ = env.step(episode.actions[k])
             assert np.allclose(obs, episode.observations[k + 1])
             assert rew == episode.rewards[k]
-            assert not term
-            assert trunc == (k == episode.total_timesteps - 1)
+            assert term == episode.terminations[k]
+            assert trunc == episode.truncations[k]
 
     check_load_and_delete_dataset(dataset_id)

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -174,6 +174,7 @@ def test_reproducibility(seed):
     for episode in dataset.sample_episodes(dataset.total_episodes):
         if seed is None:
             assert isinstance(episode.seed, int)
+            assert episode.seed >= 0
         else:
             assert seed == episode.seed
 

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -165,7 +165,12 @@ def test_reproducibility(seed):
         while not (trunc or term):
             _, _, trunc, term, _ = env.step(env.action_space.sample())
 
-    dataset = env.create_dataset(dataset_id)
+    dataset = env.create_dataset(
+        dataset_id=dataset_id,
+        algorithm_name="random_policy",
+        author="Farama",
+        author_email="farama@farama.org",
+    )
     env.close()
 
     # Step through the env again using the stored seed and check it matches
@@ -184,7 +189,7 @@ def test_reproducibility(seed):
         assert np.allclose(obs, episode.observations[0])
 
         for k in range(episode.total_timesteps):
-            obs, rew, trunc, _, _ = env.step(env.action_space.sample())
+            obs, rew, _, _, _ = env.step(env.action_space.sample())
             assert np.allclose(obs, episode.observations[k + 1])
             assert rew == episode.rewards[k]
 


### PR DESCRIPTION
# Description

This PR adds automatic seeding of environments by the DataCollector. If no explicit seed is set, one will be automatically generated when `DataCollector.reset()` is called. The seed is a `uint64`, the maximum integer supported by H5Py.

Reproducibility tests have also been added, both for when an explicit seed is set (addressing issue #15) and when autoseeding.

Other changes:
- Dummy envs are now deterministic
- Minor bugfix: `seed=0` was previously recorded as `seed=None`.

## Type of change

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes