### PR TITLE
Revert dataset spec total_steps type to int

### DIFF
--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -51,7 +51,7 @@ def parse_dataset_id(dataset_id: str) -> tuple[str | None, str, int]:
 class MinariDatasetSpec:
     env_spec: Optional[EnvSpec]
     total_episodes: int
-    total_steps: np.int64
+    total_steps: int
     dataset_id: str
     combined_datasets: List[str]
     observation_space: gym.Space
@@ -257,7 +257,7 @@ class MinariDataset:
         return len(self.episode_indices)
 
     @property
-    def total_steps(self) -> np.int64:
+    def total_steps(self) -> int:
         """Total episodes steps in the Minari dataset."""
         if self._total_steps is None:
             if self.episode_indices is None:
@@ -269,7 +269,7 @@ class MinariDataset:
                         episode_indices=self.episode_indices,
                     )
                 )
-        return np.int64(self._total_steps)
+        return int(self._total_steps)
 
     @property
     def episode_indices(self) -> np.ndarray:

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -100,6 +100,7 @@ def test_update_dataset_from_collector_env(dataset_id, env_id):
     env.add_to_dataset(dataset)
 
     assert isinstance(dataset, MinariDataset)
+    assert isinstance(dataset.total_steps, int)
     assert dataset.total_episodes == num_episodes * 2
     assert dataset.spec.total_episodes == num_episodes * 2
     assert len(dataset.episode_indices) == num_episodes * 2
@@ -170,6 +171,7 @@ def test_filter_episodes_and_subsequent_updates(dataset_id, env_id):
     env.add_to_dataset(filtered_dataset)
 
     assert isinstance(filtered_dataset, MinariDataset)
+    assert isinstance(filtered_dataset.spec.total_steps, int)
     assert filtered_dataset.total_episodes == 17
     assert filtered_dataset.spec.total_episodes == 17
     assert filtered_dataset.spec.total_steps == 17 * 5
@@ -247,6 +249,7 @@ def test_filter_episodes_and_subsequent_updates(dataset_id, env_id):
     filtered_dataset.update_dataset_from_buffer(buffer)
 
     assert isinstance(filtered_dataset, MinariDataset)
+    assert isinstance(filtered_dataset.spec.total_steps, int)
     assert filtered_dataset.total_episodes == 27
     assert filtered_dataset.spec.total_episodes == 27
     assert filtered_dataset.spec.total_steps == 27 * 5

--- a/tests/utils/test_dataset_combine.py
+++ b/tests/utils/test_dataset_combine.py
@@ -175,8 +175,9 @@ def test_combine_datasets():
     assert isinstance(combined_dataset, MinariDataset)
     assert list(combined_dataset.spec.combined_datasets) == test_datasets_ids
     assert combined_dataset.spec.total_episodes == num_datasets * num_episodes
+    assert isinstance(combined_dataset.spec.total_steps, int)
     assert combined_dataset.spec.total_steps == sum(
-        int(d.spec.total_steps) for d in test_datasets
+        d.spec.total_steps for d in test_datasets
     )
     _check_env_recovery(gym.make("CartPole-v1"), combined_dataset)
 


### PR DESCRIPTION
# Description

A [recent commit](https://github.com/Farama-Foundation/Minari/commit/dd8406ee8dce27162724fced1f7147d702a70027) modified the type of `MinariDatasetSpec.total_steps` from `int` to `np.int64` (source [here](https://github.com/Farama-Foundation/Minari/blob/e24113bf09b5b1769dafbaf6bb0b2c9b8eb9ffbe/minari/dataset/minari_dataset.py#L54)). This breaks the [TorchRL integration](https://github.com/pytorch/rl/pull/1721) as `np.int64` is not a natively JSON-encodable type. This PR reverts the type back to `int`.

One can confirm that the PR fixes the change with the following script:
```python
# Clear any cached files first: rm -r ~/.cache/torchrl/minari
from torchrl.data.datasets.minari_data import MinariExperienceReplay
data = MinariExperienceReplay("door-human-v1", batch_size=32)
```
With the current version of Minari built from source, this raises `TypeError: Object of type int64 is not JSON serializable`. 

Note: I opted to not make this a proper test, since it requires torch-nightly, which is platform-dependent and probably too cumbersome of a dependency to add to the tests.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] New and existing unit tests pass locally with my changes
