### PR TITLE
Replace dataset.name with dataset.id

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -162,7 +162,7 @@ Minari will only be able to load datasets that are stored in your `local root di
 ```python
 >>> import minari
 >>> dataset = minari.load_dataset('cartpole-test-v0')
->>> dataset.name
+>>> dataset.id
 'cartpole-test-v0'
 ```
 
@@ -361,7 +361,7 @@ Lastly, in the case of having two or more Minari datasets created with the same 
 >>> expert_dataset = minari.load_dataset('door-expert-v0')
 >>> combine_dataset = minari.combine_datasets(datasets_to_combine=[human_dataset,               expert_dataset],
                                         new_dataset_id="door-all-v0")
->>> combine_dataset.name
+>>> combine_dataset.id
 'door-all-v0'
 >>> minari.list_local_datasets()
 dict_keys(['door-all-v0', 'door-human-v0', 'door-expert-v0'])


### PR DESCRIPTION
# Description

Replace dataset.name with dataset.id in docs.
(The former throws AttributeError: 'MinariDataset' object has no attribute '_name')

## Type of change

> Please delete options that are not relevant.

- Bug fix 

### Screenshots

N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
