### PR TITLE
Ts/datasetnametoid

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -162,7 +162,7 @@ Minari will only be able to load datasets that are stored in your `local root di
 ```python
 >>> import minari
 >>> dataset = minari.load_dataset('cartpole-test-v0')
->>> dataset.name
+>>> dataset.id
 'cartpole-test-v0'
 ```
 
@@ -361,7 +361,7 @@ Lastly, in the case of having two or more Minari datasets created with the same 
 >>> expert_dataset = minari.load_dataset('door-expert-v0')
 >>> combine_dataset = minari.combine_datasets(datasets_to_combine=[human_dataset,               expert_dataset],
                                         new_dataset_id="door-all-v0")
->>> combine_dataset.name
+>>> combine_dataset.id
 'door-all-v0'
 >>> minari.list_local_datasets()
 dict_keys(['door-all-v0', 'door-human-v0', 'door-expert-v0'])

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -195,8 +195,10 @@ def test_reproducibility(seed):
         assert np.allclose(obs, episode.observations[0])
 
         for k in range(episode.total_timesteps):
+            if k==0:
+                continue # Skip first dummy action
             obs, rew, term, trunc, _ = env.step(episode.actions[k])
-            assert np.allclose(obs, episode.observations[k + 1])
+            assert np.allclose(obs, episode.observations[k])
             assert rew == episode.rewards[k]
             assert term == episode.terminations[k]
             assert trunc == episode.truncations[k]


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Change the behaviour of DataCollector by adding a dummy action, reward, truncation and termination entry at the beginning of every new episode.

This is to keep the size of all buffers the same as the size of the observations buffer (which previously included one more initial observation)

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

