### PR TITLE
Add description arg

### DIFF
--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -319,6 +319,7 @@ class DataCollector(gym.Wrapper):
         expert_policy: Optional[Callable[[ObsType], ActType]] = None,
         num_episodes_average_score: int = 100,
         minari_version: Optional[str] = None,
+        description: Optional[str] = None,
     ):
         """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollector` Minari wrapper.
 
@@ -341,6 +342,7 @@ class DataCollector(gym.Wrapper):
                                                                             `ref_max_score` and `expert_policy` can't be passed at the same time. Default to None
             num_episodes_average_score (int): number of episodes to average over the returns to compute `ref_min_score` and `ref_max_score`. Default to 100.
             minari_version (Optional[str], optional): Minari version specifier compatible with the dataset. If None (default) use the installed Minari version.
+            description (Optional[str], optional): description of the dataset being created. Defaults to None.
 
         Returns:
             MinariDataset
@@ -359,6 +361,7 @@ class DataCollector(gym.Wrapper):
             expert_policy,
             num_episodes_average_score,
             minari_version,
+            description,
         )
 
         self._save_to_disk(dataset_path, metadata)

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -347,6 +347,7 @@ def _generate_dataset_metadata(
     expert_policy: Optional[Callable[[ObsType], ActType]],
     num_episodes_average_score: int,
     minari_version: Optional[str],
+    description: Optional[str],
 ) -> Dict[str, Any]:
     """Return the metadata dictionary of the dataset."""
     dataset_metadata: Dict[str, Any] = {
@@ -384,6 +385,15 @@ def _generate_dataset_metadata(
         )
     else:
         dataset_metadata["algorithm_name"] = algorithm_name
+
+    if description is None:
+        print("here")
+        warnings.warn(
+            "`description` is set to None. For longevity purposes it is highly recommended to provide a description of the dataset",
+            UserWarning,
+        )
+    else:
+        dataset_metadata["description"] = description
 
     if minari_version is None:
         version = Version(__version__)
@@ -470,6 +480,7 @@ def create_dataset_from_buffers(
     ref_max_score: Optional[float] = None,
     expert_policy: Optional[Callable[[ObsType], ActType]] = None,
     num_episodes_average_score: int = 100,
+    description: Optional[str] = None,
 ):
     """Create Minari dataset from a list of episode dictionary buffers.
 
@@ -506,6 +517,7 @@ def create_dataset_from_buffers(
         action_space (Optional[gym.spaces.Space]): action space of the environment. If None (default) use the environment action space.
         observation_space (Optional[gym.spaces.Space]): observation space of the environment. If None (default) use the environment observation space.
         minari_version (Optional[str], optional): Minari version specifier compatible with the dataset. If None (default) use the installed Minari version.
+        description (Optional[str], optional): description of the dataset being created. Defaults to None.
 
     Returns:
         MinariDataset
@@ -547,6 +559,7 @@ def create_dataset_from_buffers(
         expert_policy,
         num_episodes_average_score,
         minari_version,
+        description,
     )
 
     storage = MinariStorage.new(

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -387,7 +387,6 @@ def _generate_dataset_metadata(
         dataset_metadata["algorithm_name"] = algorithm_name
 
     if description is None:
-        print("here")
         warnings.warn(
             "`description` is set to None. For longevity purposes it is highly recommended to provide a description of the dataset",
             UserWarning,


### PR DESCRIPTION
# Description

This PR adds an optional description arg to the `create_dataset` and `create_dataset_from_buffers` functions which allow a user to include a brief description of the dataset they are creating. If a description is not provided then a warning will be displayed to the user stating it is recommended to include one.

A minimal working example displaying usage of description:
```python
import gymnasium as gym
from minari.data_collector import DataCollector

env = gym.make("Blackjack-v1")
env = DataCollector(env)

for episode in range(10):
    done = False
    _, info = env.reset()  # {}
    while not done:
        action = env.action_space.sample()
        _, _, terminated, truncated, _ = env.step(action)
        done = terminated or truncated

dataset = env.create_dataset(
    dataset_id="blackjack-random-v1",
    algorithm_name="Random-Policy",
    code_permalink="dummy-permalink",
    author="Farama",
    author_email="dummy-email",
    minari_version="==0.4.3",
    description="A random policy for 10 fixed episodes" # commenting out this line will result in a warning to user
)
```

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

### Screenshots

N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
