### PR TITLE
Fix download flags and update CLI

### DIFF
--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -105,7 +105,7 @@ def download_dataset(dataset_id: str, force_download: bool = False):
 
     # 2. Check if there are any remote compatible versions with the local installed Minari version
     max_version = get_remote_dataset_versions(
-        download_env_name, download_dataset_name, True, True
+        download_env_name, download_dataset_name, latest_version=True, compatible_minari_version=True
     )
     if not max_version:
         if not force_download:
@@ -139,8 +139,8 @@ def download_dataset(dataset_id: str, force_download: bool = False):
         compatible_minari_version=True,
     )
     if download_version not in compatible_dataset_versions:
-        e_msg = f"The version you are trying to download for dataset, {dataset_id}, is not compatible with\
-                                    your local installed version of Minari, {__version__}."
+        e_msg = (f"The version you are trying to download for dataset, {dataset_id}, is not compatible with "
+                 f"your local installed version of Minari, {__version__}.")
         if not force_download:
             raise ValueError(
                 e_msg

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -133,7 +133,10 @@ def download_dataset(dataset_id: str, force_download: bool = False):
 
     # 4. Check that the dataset version is compatible with the local installed Minari version
     compatible_dataset_versions = get_remote_dataset_versions(
-        download_env_name, download_dataset_name, True
+        download_env_name,
+        download_dataset_name,
+        latest_version=False,
+        compatible_minari_version=True,
     )
     if download_version not in compatible_dataset_versions:
         e_msg = f"The version you are trying to download for dataset, {dataset_id}, is not compatible with\

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -658,15 +658,15 @@ def get_dataset_spec_dict(
     }
 
     if obs_space is not None:
-        dataset_observation_space = (
-            deserialize_space(obs_space).__repr__().replace("\n", "")
-        )
+        if isinstance(obs_space, (dict, str)):
+            obs_space = deserialize_space(obs_space)
+        dataset_observation_space = obs_space.__repr__().replace("\n", "")
         md_dict["Dataset Observation Space"] = f"`{dataset_observation_space}`"
 
     if action_space is not None:
-        dataset_action_space = (
-            deserialize_space(action_space).__repr__().replace("\n", "")
-        )
+        if isinstance(action_space, (dict, str)):
+            action_space = deserialize_space(action_space)
+        dataset_action_space = action_space.__repr__().replace("\n", "")
         md_dict["Dataset Action Space"] = f"`{dataset_action_space}`"
 
     add_version = f" (`{__version__}` installed)"

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -19,6 +19,7 @@ from packaging.version import Version
 
 from minari.dataset.minari_dataset import MinariDataset
 from minari.dataset.minari_storage import MinariStorage
+from minari.serialization import deserialize_space
 from minari.storage.datasets_root_dir import get_dataset_path
 
 
@@ -657,21 +658,25 @@ def get_dataset_spec_dict(
     }
 
     if obs_space is not None:
-        dataset_observation_space = obs_space.__repr__().replace("\n", "")
+        dataset_observation_space = (
+            deserialize_space(obs_space).__repr__().replace("\n", "")
+        )
         md_dict["Dataset Observation Space"] = f"`{dataset_observation_space}`"
 
     if action_space is not None:
-        dataset_action_space = action_space.__repr__().replace("\n", "")
+        dataset_action_space = (
+            deserialize_space(action_space).__repr__().replace("\n", "")
+        )
         md_dict["Dataset Action Space"] = f"`{dataset_action_space}`"
 
-    add_version = f" ({__version__} installed)"
+    add_version = f" (`{__version__}` installed)"
     md_dict.update({
         "Algorithm": dataset_spec["algorithm_name"],
         "Author": dataset_spec["author"],
         "Email": dataset_spec["author_email"],
         "Code Permalink": f"[{code_link}]({code_link})",
-        "Minari Version": f"{version} {add_version if print_version else ''}",
-        "Download": f"`minari.download_dataset(\"{dataset_spec['dataset_id']}\")`"
+        "Minari Version": f"`{version}` {add_version if print_version else ''}",
+        "Download": f"`minari.download_dataset(\"{dataset_spec['dataset_id']}\")`",
     })
 
     return md_dict

--- a/tests/dataset/test_dataset_download.py
+++ b/tests/dataset/test_dataset_download.py
@@ -117,15 +117,7 @@ def test_download_error_messages(monkeypatch):
             latest_version=False,
             compatible_minari_version=False,
         ):
-            if env_name == "door" and dataset_name == "human":
-                return versions[int(latest_version)][int(compatible_minari_version)]
-
-            return get_remote_dataset_versions(
-                env_name,
-                dataset_name,
-                latest_version=latest_version,
-                compatible_minari_version=compatible_minari_version,
-            )
+            return versions[int(latest_version)][int(compatible_minari_version)]
 
         return patched_get_remote
 
@@ -138,7 +130,7 @@ def test_download_error_messages(monkeypatch):
 
         with pytest.raises(
             ValueError,
-            match="door-human-v1, is not compatible with your local installed version of Minari, 0.4.3.",
+            match="door-human-v1, is not compatible with your local installed version of Minari",
         ):
             minari.download_dataset("door-human-v1")
 
@@ -151,7 +143,6 @@ def test_download_error_messages(monkeypatch):
     # 5. Warning to recommend downloading the latest compatible version of the dataset
     # Pretend that door-human-v2 exists and try to download door-human-v1
     with monkeypatch.context() as mp:
-        mp.setattr("minari.storage.hosting.__version__", "0.4.3")
         mp.setattr(
             "minari.storage.hosting.get_remote_dataset_versions",
             patch_get_remote_dataset_versions([[[1, 2], [1, 2]], [[2], [2]]]),

--- a/tests/dataset/test_dataset_download.py
+++ b/tests/dataset/test_dataset_download.py
@@ -79,3 +79,100 @@ def test_load_dataset_with_download(dataset_id: str):
     assert isinstance(dataset, MinariDataset)
 
     minari.delete_dataset(dataset_id)
+
+
+def test_download_error_messages(monkeypatch):
+    # 1. Check if there are any remote versions of the dataset at all
+    with pytest.raises(ValueError, match="Couldn't find any version for dataset"):
+        minari.download_dataset("non-existent-dataset-v0")
+
+    with pytest.raises(ValueError, match="Couldn't find any version for dataset"):
+        minari.download_dataset("non-existent-dataset-v0", force_download=True)
+
+    # 2. Check if there are any remote compatible versions with the local installed Minari version
+    with monkeypatch.context() as mp:
+        mp.setattr("minari.storage.hosting.__version__", "0.0.0")
+
+        with pytest.raises(
+            ValueError, match="Couldn't find any compatible version of dataset"
+        ):
+            minari.download_dataset("door-human-v1")
+
+        with pytest.warns(match="Couldn't find any compatible version of dataset"):
+            minari.download_dataset("door-human-v1", force_download=True)
+        minari.delete_dataset("door-human-v1")
+
+    # 3. Check that the dataset version exists
+    with pytest.raises(ValueError, match="doesn't exist in the remote Farama server."):
+        minari.download_dataset("door-human-v999")
+
+    with pytest.raises(ValueError, match="doesn't exist in the remote Farama server."):
+        minari.download_dataset("door-human-v999", force_download=True)
+
+    # 4. Check that the dataset version is compatible with the local installed Minari version
+    def patch_get_remote_dataset_versions(versions):
+        def patched_get_remote(
+            env_name,
+            dataset_name,
+            latest_version=False,
+            compatible_minari_version=False,
+        ):
+            if env_name == "door" and dataset_name == "human":
+                return versions[int(latest_version)][int(compatible_minari_version)]
+
+            return get_remote_dataset_versions(
+                env_name,
+                dataset_name,
+                latest_version=latest_version,
+                compatible_minari_version=compatible_minari_version,
+            )
+
+        return patched_get_remote
+
+    # Pretend that door-human-v0 is compatible but door-human-v1 is not
+    with monkeypatch.context() as mp:
+        mp.setattr(
+            "minari.storage.hosting.get_remote_dataset_versions",
+            patch_get_remote_dataset_versions([[[0, 1], [0]], [[0], [0]]]),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="door-human-v1, is not compatible with your local installed version of Minari, 0.4.3.",
+        ):
+            minari.download_dataset("door-human-v1")
+
+        with pytest.warns(
+            match="will be FORCE download but you can download the latest compatible version of this dataset"
+        ):
+            minari.download_dataset("door-human-v1", force_download=True)
+        minari.delete_dataset("door-human-v1")
+
+    # 5. Warning to recommend downloading the latest compatible version of the dataset
+    # Pretend that door-human-v2 exists and try to download door-human-v1
+    with monkeypatch.context() as mp:
+        mp.setattr("minari.storage.hosting.__version__", "0.4.3")
+        mp.setattr(
+            "minari.storage.hosting.get_remote_dataset_versions",
+            patch_get_remote_dataset_versions([[[1, 2], [1, 2]], [[2], [2]]]),
+        )
+
+        with pytest.warns(
+            match="We recommend you install a higher dataset version available and compatible"
+        ):
+            minari.download_dataset("door-human-v1")
+        minari.delete_dataset("door-human-v1")
+
+    # Skip datasets that exist locally
+    latest_door_human_id = get_latest_compatible_dataset_id(
+        env_name="door", dataset_name="human"
+    )
+    minari.download_dataset(latest_door_human_id)
+
+    with pytest.warns(
+        match=f"Skipping Download. Dataset {latest_door_human_id} found locally at"
+    ):
+        minari.download_dataset(latest_door_human_id)
+
+    minari.download_dataset(latest_door_human_id, force_download=True)
+    minari.delete_dataset(latest_door_human_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@ from typer.testing import CliRunner
 
 from minari.cli import app
 from minari.storage.hosting import list_remote_datasets
-from minari.storage.local import delete_dataset, list_local_datasets
 from tests.dataset.test_dataset_download import get_latest_compatible_dataset_id
 
 
@@ -28,13 +27,9 @@ def test_list_app():
 def test_dataset_download_then_delete(dataset_id: str):
     """Test download dataset invocation from CLI.
 
-    the downloading functionality is already tested in test_dataset_download.py so this is primarily to assert that the CLI is working as expected.
+    The downloading functionality is already tested in test_dataset_download.py so this
+    is primarily to assert that the CLI is working as expected.
     """
-    # might have to clear up the local dataset first.
-    # ideally this seems like it could just be handled by the tests
-    if dataset_id in list_local_datasets():
-        delete_dataset(dataset_id)
-
     result = runner.invoke(app, ["download", dataset_id])
 
     assert result.exit_code == 0
@@ -61,3 +56,11 @@ def test_dataset_download_then_delete(dataset_id: str):
 def test_minari_show(dataset_id):
     result = runner.invoke(app, ["show", dataset_id])
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("dataset_id", ["minigrid-fourrooms-random-v0"])
+def test_show_rendering(dataset_id: str):
+    result = runner.invoke(app, ["show", dataset_id])
+    assert result.exit_code == 0
+    # Check that the ">=" sign is rendered correctly
+    assert ">=" in result.stdout


### PR DESCRIPTION
# Description

When downloading a dataset, one of the flags in the call to `get_remote_dataset_versions` is incorrectly set, and loads a list of the latest versions rather than compatible versions. This prevents users from using older dataset versions even if they are compatible (unless they force-download first). This fixes #200. Tests have been added to check the warning/error logic in `download_dataset()`.

To make the version availability more transparent, the `minari list` CLI has been updated to show a list of compatible versions for each dataset:

<img width="1024" alt="Screenshot 2024-04-17 at 21 02 24" src="https://github.com/Farama-Foundation/Minari/assets/326411/31ab83c9-f644-468b-b857-573e49cdf854">

This PR also includes some fixes for issues in `minari show` when rendering `">="` and `serialized` spaces.


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.