### PR TITLE
Fix Black

### DIFF
--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -22,7 +22,6 @@ filtered_datasets = defaultdict(defaultdict)
 all_remote_datasets = list_remote_datasets()
 
 for dataset_id in all_remote_datasets.keys():
-
     env_name, dataset_name, version = parse_dataset_id(dataset_id)
     assert env_name is not None
 

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -163,11 +163,13 @@ def show(dataset: Annotated[str, typer.Argument()]):
             dst_metadata = remote_datasets[dataset]
         else:
             local_dataset_path = get_dataset_path("")
-            print(Text(
-                f"""The dataset `{dataset}` can't be found locally"""
-                f"""(at `{local_dataset_path}`) or remotely.""",
-                style="red",
-            ))
+            print(
+                Text(
+                    f"""The dataset `{dataset}` can't be found locally"""
+                    f"""(at `{local_dataset_path}`) or remotely.""",
+                    style="red",
+                )
+            )
             raise typer.Abort()
 
     dataset_id = dst_metadata["dataset_id"]
@@ -184,7 +186,9 @@ def show(dataset: Annotated[str, typer.Argument()]):
     dataset_spec_table.add_column(style="not bold")
 
     for key, value in get_dataset_spec_dict(dst_metadata, print_version=True).items():
-        md = Markdown(str(value), inline_code_lexer="python", inline_code_theme="monokai")
+        md = Markdown(
+            str(value), inline_code_lexer="python", inline_code_theme="monokai"
+        )
         dataset_spec_table.add_row(key, md)
 
     print(Markdown(f"""# {dataset_id_text}"""))
@@ -206,7 +210,9 @@ def show(dataset: Annotated[str, typer.Argument()]):
             env_spec_table.add_column(style="not bold")
 
             for key, value in get_env_spec_dict(env_spec).items():
-                md = Markdown(value, inline_code_lexer="python", inline_code_theme="monokai")
+                md = Markdown(
+                    value, inline_code_lexer="python", inline_code_theme="monokai"
+                )
                 env_spec_table.add_row(key, md)
 
             if env_type == "env_spec":

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -149,9 +149,7 @@ class DataCollector(gym.Wrapper):
             dict_data = {k: v for k, v in step_data.items() if k != "infos"}
         else:
             assert self._reference_info is not None
-            if not _check_infos_same_shape(
-                self._reference_info, step_data["infos"]
-            ):
+            if not _check_infos_same_shape(self._reference_info, step_data["infos"]):
                 raise ValueError(
                     "Info structure inconsistent with info structure returned by original reset."
                 )
@@ -272,7 +270,7 @@ class DataCollector(gym.Wrapper):
         self._validate_buffer()
         episode_buffer = {
             "seed": str(None) if seed is None else seed,
-            "id": self._episode_id
+            "id": self._episode_id,
         }
         self._add_step_data(episode_buffer, step_data)
         self._buffer.append(episode_buffer)
@@ -374,7 +372,7 @@ class DataCollector(gym.Wrapper):
         # will be able to calculate dataset size only after saving the disk, so updating the dataset metadata post `save_to_disk` method
 
         dataset = MinariDataset(dataset_path)
-        metadata['dataset_size'] = dataset.storage.get_size()
+        metadata["dataset_size"] = dataset.storage.get_size()
         dataset.storage.update_metadata(metadata)
         return dataset
 
@@ -441,5 +439,7 @@ def _check_infos_same_shape(info_1: dict, info_2: dict):
         if isinstance(info_1[key], dict):
             return _check_infos_same_shape(info_1[key], info_2[key])
         elif isinstance(info_1[key], np.ndarray):
-            return (info_1[key].shape == info_2[key].shape) and (info_1[key].dtype == info_2[key].dtype)
+            return (info_1[key].shape == info_2[key].shape) and (
+                info_1[key].dtype == info_2[key].dtype
+            )
     return True

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -75,6 +75,7 @@ class MinariStorage(ABC):
                 action_space = env.action_space
 
         from minari.dataset.storages import registry  # avoid circular import
+
         return registry[metadata["data_format"]](
             data_path, observation_space, action_space
         )
@@ -109,8 +110,11 @@ class MinariStorage(ABC):
                 "Since env_spec is not specified, you need to specify both action space and observation space"
             )
         from minari.dataset.storages import registry  # avoid circular import
+
         if data_format not in registry.keys():
-            raise ValueError(f"No storage implemented for {data_format}. Available formats: {registry.keys()}")
+            raise ValueError(
+                f"No storage implemented for {data_format}. Available formats: {registry.keys()}"
+            )
 
         data_path = pathlib.Path(data_path)
         data_path.mkdir(exist_ok=True)
@@ -262,7 +266,7 @@ class MinariStorage(ABC):
         """
         datasize = 0
         if self.data_path.exists():
-            for filename in self.data_path.glob('**/*'):
+            for filename in self.data_path.glob("**/*"):
                 st_size = self.data_path.joinpath(filename).stat().st_size
                 datasize += st_size / 1000000
 

--- a/minari/dataset/storages/hdf5_storage.py
+++ b/minari/dataset/storages/hdf5_storage.py
@@ -47,9 +47,13 @@ class _HDF5Storage(MinariStorage):
 
         sentinel = object()
         with h5py.File(self._file_path, "a") as file:
-            for metadata, episode_id in zip_longest(metadatas, episode_indices, fillvalue=sentinel):
+            for metadata, episode_id in zip_longest(
+                metadatas, episode_indices, fillvalue=sentinel
+            ):
                 if sentinel in (metadata, episode_id):
-                    raise ValueError('Metadatas and episode_indices have different lengths')
+                    raise ValueError(
+                        "Metadatas and episode_indices have different lengths"
+                    )
 
                 assert isinstance(metadata, dict)
                 ep_group = file[f"episode_{episode_id}"]
@@ -123,7 +127,7 @@ class _HDF5Storage(MinariStorage):
                     "actions": self._decode_space(
                         ep_group["actions"], self.action_space
                     ),
-                    "infos": infos
+                    "infos": infos,
                 }
                 for key in {"rewards", "terminations", "truncations"}:
                     group_value = ep_group[key]
@@ -222,7 +226,9 @@ def _add_episode_to_group(episode_buffer: Dict, episode_group: h5py.Group):
             }
             episode_group_to_clear = _get_from_h5py(episode_group, key)
             _add_episode_to_group(dict_data, episode_group_to_clear)
-        elif all(isinstance(entry, OrderedDict) for entry in data):  # list of OrderedDict
+        elif all(
+            isinstance(entry, OrderedDict) for entry in data
+        ):  # list of OrderedDict
             dict_data = {key: [entry[key] for entry in data] for key in data[0].keys()}
             episode_group_to_clear = _get_from_h5py(episode_group, key)
             _add_episode_to_group(dict_data, episode_group_to_clear)

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -105,7 +105,10 @@ def download_dataset(dataset_id: str, force_download: bool = False):
 
     # 2. Check if there are any remote compatible versions with the local installed Minari version
     max_version = get_remote_dataset_versions(
-        download_env_name, download_dataset_name, latest_version=True, compatible_minari_version=True
+        download_env_name,
+        download_dataset_name,
+        latest_version=True,
+        compatible_minari_version=True,
     )
     if not max_version:
         if not force_download:
@@ -139,8 +142,10 @@ def download_dataset(dataset_id: str, force_download: bool = False):
         compatible_minari_version=True,
     )
     if download_version not in compatible_dataset_versions:
-        e_msg = (f"The version you are trying to download for dataset, {dataset_id}, is not compatible with "
-                 f"your local installed version of Minari, {__version__}.")
+        e_msg = (
+            f"The version you are trying to download for dataset, {dataset_id}, is not compatible with "
+            f"your local installed version of Minari, {__version__}."
+        )
         if not force_download:
             raise ValueError(
                 e_msg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ include = ["minari", "minari.*"]
 
 [tool.black]
 safe = true
-force-exclude = ["docs/tutorials/using_datasets/behavioral_cloning.py"]
+force-exclude = "docs/tutorials/"
 
 [tool.isort]
 atomic = true

--- a/tests/common.py
+++ b/tests/common.py
@@ -153,9 +153,9 @@ class DummyDictEnv(gym.Env):
 
     def _get_info(self):
         return {
-                "timestep": np.array([self.timestep]),
-                "component_1": {"next_timestep": np.array([self.timestep + 1])},
-            }
+            "timestep": np.array([self.timestep]),
+            "component_1": {"next_timestep": np.array([self.timestep + 1])},
+        }
 
     def step(self, action):
         terminated = self.timestep > 5
@@ -288,7 +288,6 @@ class DummyComboEnv(gym.Env):
 
 
 def register_dummy_envs():
-
     register(
         id="DummyBoxEnv-v0",
         entry_point="tests.common:DummyBoxEnv",
@@ -715,8 +714,7 @@ def check_episode_data_integrity(
             obs = _reconstuct_obs_or_action_at_index_recursive(episode.observations, i)
             if info_sample is not None:
                 assert check_infos_equal(
-                    get_info_at_step_index(episode.infos, i),
-                    info_sample
+                    get_info_at_step_index(episode.infos, i), info_sample
                 )
 
             assert observation_space.contains(obs)
@@ -744,7 +742,6 @@ def check_infos_equal(info_1: Dict, info_2: Dict) -> bool:
 
 
 def _space_subset_helper(entry: Dict):
-
     return OrderedDict(
         {
             "component_2": OrderedDict(
@@ -755,7 +752,6 @@ def _space_subset_helper(entry: Dict):
 
 
 def get_sample_buffer_for_dataset_from_env(env: gym.Env, num_episodes: int = 10):
-
     buffer = []
     observations = []
     actions = []

--- a/tests/data_collector/callbacks/test_step_data_callback.py
+++ b/tests/data_collector/callbacks/test_step_data_callback.py
@@ -164,9 +164,8 @@ def test_data_collector_step_data_callback_info_correction():
     # structure across steps, it is caught by the data_collector
     with pytest.raises(
         ValueError,
-        match=r"Info structure inconsistent with info structure returned by original reset."
+        match="Info structure inconsistent with info structure returned by original reset.",
     ):
-
         num_episodes = 10
         env.reset(seed=42)
         for _ in range(num_episodes):

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -73,7 +73,6 @@ def test_episode_data(space: gym.Space):
     ],
 )
 def test_update_dataset_from_collector_env(dataset_id, env_id):
-
     local_datasets = minari.list_local_datasets()
     if dataset_id in local_datasets:
         minari.delete_dataset(dataset_id)
@@ -396,7 +395,6 @@ def test_iterate_episodes(dataset_id, env_id):
     ],
 )
 def test_update_dataset_from_buffer(dataset_id, env_id):
-
     local_datasets = minari.list_local_datasets()
     if dataset_id in local_datasets:
         minari.delete_dataset(dataset_id)
@@ -483,7 +481,9 @@ def test_missing_env_module():
     path = os.path.join(dataset.storage.data_path, METADATA_FILE_NAME)
     with open(path) as file:
         metadata = json.load(file)
-    metadata["env_spec"] = r"""{
+    metadata[
+        "env_spec"
+    ] = r"""{
         "id": "DummyEnv-v0",
         "entry_point": "dummymodule:dummyenv",
         "reward_threshold": null,

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -233,7 +233,7 @@ def test_minari_get_dataset_size_from_collector_env(dataset_id, env_id):
         author_email="wdudley@farama.org",
     )
 
-    assert dataset.storage.metadata['dataset_size'] == dataset.storage.get_size()
+    assert dataset.storage.metadata["dataset_size"] == dataset.storage.get_size()
 
     check_data_integrity(dataset.storage, dataset.episode_indices)
 
@@ -320,7 +320,7 @@ def test_minari_get_dataset_size_from_buffer(dataset_id, env_id):
         author_email="wdudley@farama.org",
     )
 
-    assert dataset.storage.metadata['dataset_size'] == dataset.storage.get_size()
+    assert dataset.storage.metadata["dataset_size"] == dataset.storage.get_size()
 
     check_data_integrity(dataset.storage, dataset.episode_indices)
 

--- a/tests/integrations/test_agile_rl.py
+++ b/tests/integrations/test_agile_rl.py
@@ -16,12 +16,10 @@ def dataset_id():
 
 @pytest.fixture(autouse=True)
 def createAndDestroyMinariDataset(dataset_id):
-    env = gym.make('CartPole-v1')
+    env = gym.make("CartPole-v1")
     env = DataCollector(env, record_infos=True, max_buffer_steps=100000)
 
-    create_dummy_dataset_with_collecter_env_helper(
-        dataset_id, env, num_episodes=10
-    )
+    create_dummy_dataset_with_collecter_env_helper(dataset_id, env, num_episodes=10)
 
     yield
 
@@ -49,10 +47,9 @@ def test_agile_create_buffer(dataset_id):
     """
 
     field_names = ["state", "action", "reward", "next_state", "done"]
-    memory = ReplayBuffer(action_dim=2,
-                          memory_size=10000,
-                          field_names=field_names,
-                          device="cpu")
+    memory = ReplayBuffer(
+        action_dim=2, memory_size=10000, field_names=field_names, device="cpu"
+    )
 
     assert memory.counter == 0
 

--- a/tests/integrations/test_torch_rl.py
+++ b/tests/integrations/test_torch_rl.py
@@ -21,8 +21,8 @@ def test_torch_minari_experience_replay():
     assert sample.batch_size[0] == batch_size
     assert sample.shape[0] == batch_size
 
-    assert sample[0]['action'].shape == env.action_space.shape
-    assert sample[0]['observation'].shape == env.observation_space.shape
+    assert sample[0]["action"].shape == env.action_space.shape
+    assert sample[0]["observation"].shape == env.observation_space.shape
 
     # Check that the dataset cannot be written to
     with pytest.raises(RuntimeError):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -10,11 +10,7 @@ def test_readme():
     check_md_file(fpath=fpath)
 
 
-@pytest.mark.parametrize(
-        'fpath',
-        [*pathlib.Path("docs").glob("**/*.md")],
-        ids=str
-)
+@pytest.mark.parametrize("fpath", [*pathlib.Path("docs").glob("**/*.md")], ids=str)
 def test_markdown(fpath):
     check_md_file(fpath=fpath, lang="bash")
     check_md_file(fpath=fpath)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,7 +6,6 @@ from tests.common import test_spaces, unsupported_test_spaces
 
 @pytest.mark.parametrize("space", test_spaces)
 def test_space_serialize_deserialize(space):
-
     space_str = serialize_space(space)
     reconstructed_space = deserialize_space(space_str)
     reserialized_space_str = serialize_space(reconstructed_space)
@@ -22,7 +21,6 @@ def test_space_serialize_deserialize(space):
 
 @pytest.mark.parametrize("space", unsupported_test_spaces)
 def test_space_serialize_deserialize_unsupported(space):
-
     with pytest.raises(
         NotImplementedError, match=r"No serialization method available for .+"
     ):

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -100,15 +100,15 @@ def test_generate_dataset_with_collector_env(dataset_id, env_id):
 @pytest.mark.parametrize(
     "info_override",
     [
-        None, {}, {"foo": np.ones((10, 10), dtype=np.float32)},
-        {"int": 1}, {"bool": False},
+        None,
+        {},
+        {"foo": np.ones((10, 10), dtype=np.float32)},
+        {"int": 1},
+        {"bool": False},
         {
             "value1": True,
             "value2": 5,
-            "value3": {
-                "nested1": False,
-                "nested2": np.empty(10)
-            }
+            "value3": {"nested1": False, "nested2": np.empty(10)},
         },
     ],
 )
@@ -250,7 +250,9 @@ def test_generate_dataset_with_external_buffer(dataset_id, env_id):
         assert len(dataset.episode_indices) == num_episodes
 
         check_data_integrity(dataset.storage, dataset.episode_indices)
-        check_episode_data_integrity(dataset, dataset.spec.observation_space, dataset.spec.action_space)
+        check_episode_data_integrity(
+            dataset, dataset.spec.observation_space, dataset.spec.action_space
+        )
         check_env_recovery(env, dataset, eval_env)
 
         check_load_and_delete_dataset(dataset_id)
@@ -319,7 +321,9 @@ def test_generate_dataset_with_space_subset_external_buffer(is_env_needed):
     assert len(dataset.episode_indices) == num_episodes
 
     check_data_integrity(dataset.storage, dataset.episode_indices)
-    check_episode_data_integrity(dataset, dataset.spec.observation_space, dataset.spec.action_space)
+    check_episode_data_integrity(
+        dataset, dataset.spec.observation_space, dataset.spec.action_space
+    )
     if is_env_needed:
         check_env_recovery_with_subset_spaces(
             env, dataset, action_space_subset, observation_space_subset


### PR DESCRIPTION
# Description

The `force-exclude` setting for the Black configuration in `pyproject.toml` is a regex which was incorrectly set, matching and excluding a significant proportion of the codebase. This PR fixes that setting. The changes outside `pyproject.toml` are due to Black formatting.


## Type of change

- Bug fix (non-breaking change which fixes an issue)
