### PR TITLE
ENH: Make author and email as set

### DIFF
--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -37,8 +37,8 @@ When creating a Minari dataset the default global metadata will be the following
 | `observation_space`     | `gymnasium.Space`      | Gymnasium observation space describing observations in dataset. |
 | `env_spec`              | `str`      | JSON string of the Gymnasium environment spec.|
 | `code_permalink`        | `str`      | Link to a repository with the code used to generate the dataset.|
-| `author`                | `str`      | Author's name that created the dataset. |
-| `author_email`          | `str`      | Email of the author that created the dataset.|
+| `author`                | `set of str`      | Name of the authors that created the dataset. |
+| `author_email`          | `set of str`      | Email of the authors that created the dataset.|
 | `algorithm_name`        | `str`      | Name of the expert policy used to create the dataset. |
 | `minari_version`        | `str`      | Version of Minari that generated the dataset. |
 

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -1,7 +1,7 @@
 """Minari CLI commands."""
 import os
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 from typing_extensions import Annotated
 
 import typer
@@ -59,13 +59,13 @@ def _show_dataset_table(datasets: Dict[str, Dict[str, Any]], table_title: str):
         dst_metadata = datasets[dataset_id]
 
         author = dst_metadata.get("author", "Unknown")
-        if isinstance(author, set):
+        if isinstance(author, Iterable):
             author = ", ".join(author)
         dataset_size = dst_metadata.get("dataset_size", "Unknown")
         if dataset_size != "Unknown":
             dataset_size = f"{str(dataset_size)} MB"
         author_email = dst_metadata.get("author_email", "Unknown")
-        if isinstance(author_email, set):
+        if isinstance(author_email, Iterable):
             author_email = ", ".join(author_email)
 
         assert isinstance(dst_metadata["dataset_id"], str)

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -59,10 +59,14 @@ def _show_dataset_table(datasets: Dict[str, Dict[str, Any]], table_title: str):
         dst_metadata = datasets[dataset_id]
 
         author = dst_metadata.get("author", "Unknown")
+        if isinstance(author, set):
+            author = ", ".join(author)
         dataset_size = dst_metadata.get("dataset_size", "Unknown")
         if dataset_size != "Unknown":
             dataset_size = f"{str(dataset_size)} MB"
         author_email = dst_metadata.get("author_email", "Unknown")
+        if isinstance(author_email, set):
+            author_email = ", ".join(author_email)
 
         assert isinstance(dst_metadata["dataset_id"], str)
         assert isinstance(author, str)

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -229,8 +229,8 @@ class DataCollector(gym.Wrapper):
         dataset_id: str,
         eval_env: Optional[str | gym.Env | EnvSpec] = None,
         algorithm_name: Optional[str] = None,
-        author: Optional[str] = None,
-        author_email: Optional[str] = None,
+        author: Optional[str | set] = None,
+        author_email: Optional[str | set] = None,
         code_permalink: Optional[str] = None,
         ref_min_score: Optional[float] = None,
         ref_max_score: Optional[float] = None,
@@ -246,19 +246,18 @@ class DataCollector(gym.Wrapper):
 
         Args:
             dataset_id (str): name id to identify Minari dataset
-            buffer (list[Dict[str, Union[list, Dict]]]): list of episode dictionaries with data
-            eval_env (Optional[str|gym.Env|EnvSpec]): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) to use for evaluation with the dataset. After loading the dataset, the environment can be recovered as follows: `MinariDataset.recover_environment(eval_env=True).
+            eval_env (str | gym.Env | EnvSpec, optional): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) to use for evaluation with the dataset. After loading the dataset, the environment can be recovered as follows: `MinariDataset.recover_environment(eval_env=True).
                                                     If None the `env` used to collect the buffer data should be used for evaluation.
-            algorithm_name (Optional[str], optional): name of the algorithm used to collect the data. Defaults to None.
-            author (Optional[str], optional): author that generated the dataset. Defaults to None.
-            author_email (Optional[str], optional): email of the author that generated the dataset. Defaults to None.
-            code_permalink (Optional[str], optional): link to relevant code used to generate the dataset. Defaults to None.
-            ref_min_score( Optional[float], optional): minimum reference score from the average returns of a random policy. This value is later used to normalize a score with :meth:`minari.get_normalized_score`. If default None the value will be estimated with a default random policy.
-            ref_max_score (Optional[float], optional: maximum reference score from the average returns of a hypothetical expert policy. This value is used in :meth:`minari.get_normalized_score`. Default None.
-            expert_policy (Optional[Callable[[ObsType], ActType], optional): policy to compute `ref_max_score` by averaging the returns over a number of episodes equal to  `num_episodes_average_score`.
+            algorithm_name (str, optional): name of the algorithm used to collect the data. Defaults to None.
+            author (str | set, optional): name of the author(s) that generated the dataset. Defaults to None.
+            author_email (str | set, optional): email(s) of the author(s) that generated the dataset. Defaults to None.
+            code_permalink (str, optional): link to relevant code used to generate the dataset. Defaults to None.
+            ref_min_score(float, optional): minimum reference score from the average returns of a random policy. This value is later used to normalize a score with :meth:`minari.get_normalized_score`. If default None the value will be estimated with a default random policy.
+            ref_max_score (float, optional): maximum reference score from the average returns of a hypothetical expert policy. This value is used in :meth:`minari.get_normalized_score`. Default None.
+            expert_policy (Callable[[ObsType], ActType], optional): policy to compute `ref_max_score` by averaging the returns over a number of episodes equal to  `num_episodes_average_score`.
                                                                             `ref_max_score` and `expert_policy` can't be passed at the same time. Default to None
             num_episodes_average_score (int): number of episodes to average over the returns to compute `ref_min_score` and `ref_max_score`. Default to 100.
-            description (Optional[str], optional): description of the dataset being created. Defaults to None.
+            description (str, optional): description of the dataset being created. Defaults to None.
 
         Returns:
             MinariDataset
@@ -281,11 +280,8 @@ class DataCollector(gym.Wrapper):
 
         self._save_to_disk(dataset_path, metadata)
 
-        # will be able to calculate dataset size only after saving the disk, so updating the dataset metadata post `save_to_disk` method
-
         dataset = MinariDataset(dataset_path)
-        metadata["dataset_size"] = dataset.storage.get_size()
-        dataset.storage.update_metadata(metadata)
+        dataset.storage.update_metadata({"dataset_size": dataset.storage.get_size()})
         return dataset
 
     def _flush_to_storage(self):

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -216,8 +216,8 @@ def _generate_dataset_metadata(
     env_spec: Optional[EnvSpec],
     eval_env: Optional[str | gym.Env | EnvSpec],
     algorithm_name: Optional[str],
-    author: Optional[str],
-    author_email: Optional[str],
+    author: Optional[str | set[str]],
+    author_email: Optional[str | set[str]],
     code_permalink: Optional[str],
     ref_min_score: Optional[float],
     ref_max_score: Optional[float],
@@ -244,7 +244,7 @@ def _generate_dataset_metadata(
             UserWarning,
         )
     else:
-        dataset_metadata["author"] = author
+        dataset_metadata["author"] = {author} if isinstance(author, str) else author
 
     if author_email is None:
         warnings.warn(
@@ -252,7 +252,9 @@ def _generate_dataset_metadata(
             UserWarning,
         )
     else:
-        dataset_metadata["author_email"] = author_email
+        dataset_metadata["author_email"] = (
+            {author_email} if isinstance(author_email, str) else author_email
+        )
 
     if algorithm_name is None:
         warnings.warn(
@@ -330,8 +332,8 @@ def create_dataset_from_buffers(
     env: Optional[str | gym.Env | EnvSpec] = None,
     eval_env: Optional[str | gym.Env | EnvSpec] = None,
     algorithm_name: Optional[str] = None,
-    author: Optional[str] = None,
-    author_email: Optional[str] = None,
+    author: Optional[str | set[str]] = None,
+    author_email: Optional[str | set[str]] = None,
     code_permalink: Optional[str] = None,
     action_space: Optional[gym.spaces.Space] = None,
     observation_space: Optional[gym.spaces.Space] = None,
@@ -351,23 +353,23 @@ def create_dataset_from_buffers(
     Args:
         dataset_id (str): name id to identify Minari dataset.
         buffer (list[EpisodeBuffer]): list of episode buffer with data.
-        env (Optional[str|gym.Env|EnvSpec]): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) used to collect the buffer data. Defaults to None.
-        eval_env (Optional[str|gym.Env|EnvSpec]): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) to use for evaluation with the dataset. After loading the dataset, the environment can be recovered as follows: `MinariDataset.recover_environment(eval_env=True).
+        env (str | gym.Env | EnvSpec, optional): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) used to collect the buffer data. Defaults to None.
+        eval_env (str | gym.Env | EnvSpec, optional): Gymnasium environment(gym.Env)/environment id(str)/environment spec(EnvSpec) to use for evaluation with the dataset. After loading the dataset, the environment can be recovered as follows: `MinariDataset.recover_environment(eval_env=True).
                                                 If None, and if the `env` used to collect the buffer data is available, latter will be used for evaluation.
-        algorithm_name (Optional[str], optional): name of the algorithm used to collect the data. Defaults to None.
-        author (Optional[str], optional): author that generated the dataset. Defaults to None.
-        author_email (Optional[str], optional): email of the author that generated the dataset. Defaults to None.
-        code_permalink (Optional[str], optional): link to relevant code used to generate the dataset. Defaults to None.
-        ref_min_score (Optional[float], optional): minimum reference score from the average returns of a random policy. This value is later used to normalize a score with :meth:`minari.get_normalized_score`. If default None the value will be estimated with a default random policy.
+        algorithm_name (str, optional): name of the algorithm used to collect the data. Defaults to None.
+        author (str | set, optional): name of the author(s) that generated the dataset. Defaults to None.
+        author_email (str | set, optional): email(s) of the author(s) that generated the dataset. Defaults to None.
+        code_permalink (str, optional): link to relevant code used to generate the dataset. Defaults to None.
+        ref_min_score (float, optional): minimum reference score from the average returns of a random policy. This value is later used to normalize a score with :meth:`minari.get_normalized_score`. If default None the value will be estimated with a default random policy.
                                                     Also note that this attribute will be added to the Minari dataset only if `ref_max_score` or `expert_policy` are assigned a valid value other than None.
-        ref_max_score (Optional[float], optional: maximum reference score from the average returns of a hypothetical expert policy. This value is used in `MinariDataset.get_normalized_score()`. Default None.
-        expert_policy (Optional[Callable[[ObsType], ActType], optional): policy to compute `ref_max_score` by averaging the returns over a number of episodes equal to  `num_episodes_average_score`.
+        ref_max_score (float, optional): maximum reference score from the average returns of a hypothetical expert policy. This value is used in `MinariDataset.get_normalized_score()`. Default None.
+        expert_policy (Callable[[ObsType], ActType], optional): policy to compute `ref_max_score` by averaging the returns over a number of episodes equal to  `num_episodes_average_score`.
                                                                         `ref_max_score` and `expert_policy` can't be passed at the same time. Default to None
         num_episodes_average_score (int): number of episodes to average over the returns to compute `ref_min_score` and `ref_max_score`. Default to 100.
                 observation_space:
-        action_space (Optional[gym.spaces.Space]): action space of the environment. If None (default) use the environment action space.
-        observation_space (Optional[gym.spaces.Space]): observation space of the environment. If None (default) use the environment observation space.
-        description (Optional[str], optional): description of the dataset being created. Defaults to None.
+        action_space (gym.spaces.Space, optional): action space of the environment. If None (default) use the environment action space.
+        observation_space (gym.spaces.Space, optional): observation space of the environment. If None (default) use the environment observation space.
+        description (str, optional): description of the dataset being created. Defaults to None.
         data_format (str, optional): Data format to store the data in the Minari dataset. If None (defaults), it will use the default format of MinariStorage.
 
     Returns:
@@ -423,12 +425,9 @@ def create_dataset_from_buffers(
         **data_format_kwarg,
     )
 
-    # adding `update_metadata` before hand too, as for small envs, the absence of metadata is causing a difference of some 10ths of MBs leading to errors in unit tests.
     storage.update_metadata(metadata)
     storage.update_episodes(buffer)
-
-    metadata["dataset_size"] = storage.get_size()
-    storage.update_metadata(metadata)
+    storage.update_metadata({"dataset_size": storage.get_size()})
 
     return MinariDataset(storage)
 
@@ -527,11 +526,19 @@ def get_dataset_spec_dict(dataset_spec: Dict) -> Dict[str, str]:
     supported = (
         "supported" if version in supported_dataset_versions else "not supported"
     )
+    author = dataset_spec.get("author", "Not provided")
+    if isinstance(author, set):
+        author = ", ".join(author)
+    email = dataset_spec.get("author_email", "Not provided")
+    if isinstance(email, set):
+        email = ", ".join(email)
+    assert isinstance(author, str)
+    assert isinstance(email, str)
     md_dict.update(
         {
             "Algorithm": dataset_spec.get("algorithm_name", "Not provided"),
-            "Author": dataset_spec.get("author", "Not provided"),
-            "Email": dataset_spec.get("author_email", "Not provided"),
+            "Author": author,
+            "Email": email,
             "Code Permalink": f"[{code_link}]({code_link})",
             "Minari Version": f"`{version}` ({supported})",
             "Download": f"`minari download {dataset_spec['dataset_id']}`",

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -5,7 +5,7 @@ import importlib.metadata
 import os
 import re
 import warnings
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 import gymnasium as gym
 import numpy as np
@@ -527,10 +527,10 @@ def get_dataset_spec_dict(dataset_spec: Dict) -> Dict[str, str]:
         "supported" if version in supported_dataset_versions else "not supported"
     )
     author = dataset_spec.get("author", "Not provided")
-    if isinstance(author, set):
+    if isinstance(author, Iterable):
         author = ", ".join(author)
     email = dataset_spec.get("author_email", "Not provided")
-    if isinstance(email, set):
+    if isinstance(email, Iterable):
         email = ", ".join(email)
     assert isinstance(author, str)
     assert isinstance(email, str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,6 @@ reportPrivateUsage = "warning"
 reportUnboundVariable = "warning"
 
 [tool.pytest.ini_options]
-filterwarnings = [
-    'ignore:.*`eval_env` is set to None',
-    "ignore:.*`description` is set to None",
-    "ignore:.*`code_permalink` is set to None"
-]
+filterwarnings = ['ignore:.*`eval_env` is set to None']
 # filterwarnings = ['ignore:.*step API.*:DeprecationWarning']
 addopts = ["--ignore=docs/tutorials"]

--- a/tests/common.py
+++ b/tests/common.py
@@ -621,8 +621,9 @@ def create_dummy_dataset_with_collecter_env_helper(
         dataset_id=dataset_id,
         algorithm_name="random_policy",
         code_permalink="https://github.com/Farama-Foundation/Minari/blob/main/tests/common.py",
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        author="Farama",
+        author_email="farama@farama.org",
+        description="Test dataset for Minari",
         **kwargs,
     )
 

--- a/tests/data_collector/callbacks/test_step_data_callback.py
+++ b/tests/data_collector/callbacks/test_step_data_callback.py
@@ -90,8 +90,9 @@ def test_data_collector_step_data_callback(data_format, register_dummy_envs):
         dataset_id=dataset_id,
         algorithm_name="random_policy",
         code_permalink=str(__file__),
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        author="Farama",
+        author_email="farama@farama.org",
+        description="Test dataset",
     )
 
     assert isinstance(dataset, MinariDataset)
@@ -139,8 +140,9 @@ def test_data_collector_step_data_callback_info_correction(
         dataset_id=dataset_id,
         algorithm_name="random_policy",
         code_permalink=str(__file__),
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        author="Farama",
+        author_email="farama@farama.org",
+        description="Test dataset",
     )
 
     assert isinstance(dataset, MinariDataset)

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -123,6 +123,8 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
         algorithm_name="random_policy",
         author="Farama",
         author_email="farama@farama.org",
+        code_permalink=str(__file__),
+        description="Test truncation without reset.",
     )
 
     env.close()
@@ -178,6 +180,8 @@ def test_reproducibility(seed, data_format, register_dummy_envs):
         algorithm_name="random_policy",
         author="Farama",
         author_email="farama@farama.org",
+        code_permalink=str(__file__),
+        description="Test reproducibility",
     )
     env.close()
 

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -219,9 +219,10 @@ def test_minari_get_dataset_size_from_collector_env(
     dataset = env.create_dataset(
         dataset_id=dataset_id,
         algorithm_name="random_policy",
-        code_permalink="https://github.com/Farama-Foundation/Minari/blob/f095bfe07f8dc6642082599e07779ec1dd9b2667/tutorials/LocalStorage/local_storage.py",
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        code_permalink=str(__file__),
+        author="Farama",
+        author_email="farama@farama.org",
+        description="Test dataset",
     )
 
     assert dataset.storage.metadata["dataset_size"] == dataset.storage.get_size()
@@ -292,10 +293,11 @@ def test_minari_get_dataset_size_from_buffer(
         env=env,
         buffer=buffer,
         algorithm_name="random_policy",
-        code_permalink="https://github.com/Farama-Foundation/Minari/blob/f095bfe07f8dc6642082599e07779ec1dd9b2667/tutorials/LocalStorage/local_storage.py",
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        code_permalink=str(__file__),
+        author="Farama",
+        author_email="farama@farama.org",
         data_format=data_format,
+        description="Test dataset",
     )
 
     assert dataset.storage.metadata["dataset_size"] == dataset.storage.get_size()

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -68,15 +68,16 @@ def test_generate_dataset_with_collector_env(dataset_id, env_id, register_dummy_
         eval_env=eval_env,
         algorithm_name="random_policy",
         code_permalink=CODELINK,
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        author="Farama",
+        author_email="farama@farama.org",
+        description="Test dataset",
     )
 
     metadata = dataset.storage.metadata
     assert metadata["algorithm_name"] == "random_policy"
     assert metadata["code_permalink"] == CODELINK
-    assert metadata["author"] == "WillDudley"
-    assert metadata["author_email"] == "wdudley@farama.org"
+    assert metadata["author"] == {"Farama"}
+    assert metadata["author_email"] == {"farama@farama.org"}
 
     assert isinstance(dataset, MinariDataset)
     assert dataset.total_episodes == num_episodes
@@ -135,8 +136,9 @@ def test_record_infos_collector_env(info_override, register_dummy_envs):
         dataset_id=dataset_id,
         algorithm_name="random_policy",
         code_permalink=CODELINK,
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        author={"Farama", "Contributors"},
+        author_email={"farama@farama.org"},
+        description="Test dataset",
     )
 
     assert isinstance(dataset, MinariDataset)
@@ -227,8 +229,9 @@ def test_generate_dataset_with_external_buffer(
             eval_env=eval_env_dataset_id,
             algorithm_name="random_policy",
             code_permalink=CODELINK,
-            author="WillDudley",
-            author_email="wdudley@farama.org",
+            author="Farama",
+            author_email="farama@farama.org",
+            description="Test dataset",
             data_format=data_format,
         )
 
@@ -320,8 +323,9 @@ def test_generate_dataset_with_space_subset_external_buffer(
         env=env_to_pass,
         algorithm_name="random_policy",
         code_permalink=CODELINK,
-        author="WillDudley",
-        author_email="wdudley@farama.org",
+        author={"Farama", "Contributors"},
+        author_email={"farama@farama.org", "contributors@farama.org"},
+        description="Test dataset",
         action_space=action_space_subset,
         observation_space=observation_space_subset,
         data_format=data_format,
@@ -330,8 +334,8 @@ def test_generate_dataset_with_space_subset_external_buffer(
     metadata = dataset.storage.metadata
     assert metadata["algorithm_name"] == "random_policy"
     assert metadata["code_permalink"] == CODELINK
-    assert metadata["author"] == "WillDudley"
-    assert metadata["author_email"] == "wdudley@farama.org"
+    assert metadata["author"] == {"Farama", "Contributors"}
+    assert metadata["author_email"] == {"farama@farama.org", "contributors@farama.org"}
 
     assert isinstance(dataset, MinariDataset)
     assert dataset.total_episodes == num_episodes


### PR DESCRIPTION
Make author and email as set in metadata. This allow to correctly have the list of authors when combining multiple datasets
