### PR TITLE
Add namespaces

### DIFF
--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -7,7 +7,7 @@ from generate_gif import generate_gif
 from gymnasium.envs.registration import EnvSpec
 
 from minari import list_remote_datasets
-from minari.dataset.minari_dataset import parse_dataset_id
+from minari.dataset.minari_dataset import gen_dataset_id, parse_dataset_id
 from minari.storage.hosting import get_remote_dataset_versions
 from minari.utils import get_dataset_spec_dict, get_env_spec_dict
 
@@ -23,12 +23,16 @@ filtered_datasets = defaultdict(defaultdict)
 all_remote_datasets = list_remote_datasets()
 
 for dataset_id in all_remote_datasets.keys():
-    env_name, dataset_name, version = parse_dataset_id(dataset_id)
+    namespace, env_name, dataset_name, version = parse_dataset_id(dataset_id)
     assert env_name is not None
 
     if dataset_name not in filtered_datasets[env_name]:
-        max_version = get_remote_dataset_versions(env_name, dataset_name, True)[0]
-        max_version_dataset_id = "-".join([env_name, dataset_name, f"v{max_version}"])
+        max_version = get_remote_dataset_versions(
+            namespace, env_name, dataset_name, latest_version=True
+        )[0]
+        max_version_dataset_id = gen_dataset_id(
+            namespace, env_name, dataset_name, max_version
+        )
         filtered_datasets[env_name][dataset_name] = all_remote_datasets[
             max_version_dataset_id
         ]

--- a/docs/api/minari_functions.md
+++ b/docs/api/minari_functions.md
@@ -7,6 +7,7 @@ minari_dataset/minari_dataset
 minari_dataset/minari_storage
 minari_dataset/episode_data
 minari_dataset/step_data
+namespace/namespace
 ```
 
 ## Load Minari Dataset

--- a/docs/api/namespace/namespace.md
+++ b/docs/api/namespace/namespace.md
@@ -1,0 +1,44 @@
+# Namespace
+
+## Create Namespace
+
+```{eval-rst}
+.. autofunction:: minari.namespace.create_namespace
+```
+
+## Update Namespace
+
+```{eval-rst}
+.. autofunction:: minari.namespace.update_namespace
+```
+
+## Get Local Namespace Metadata
+
+```{eval-rst}
+.. autofunction:: minari.namespace.get_namespace_metadata
+```
+
+## Download Namespace Metadata
+
+```{eval-rst}
+.. autofunction:: minari.namespace.download_namespace_metadata
+```
+
+## Upload Namespace
+
+```{eval-rst}
+.. autofunction:: minari.namespace.upload_namespace
+```
+
+## List Namespaces
+
+```{eval-rst}
+.. autofunction:: minari.namespace.list_local_namespaces
+.. autofunction:: minari.namespace.list_remote_namespaces
+```
+
+## Delete Namespace
+
+```{eval-rst}
+.. autofunction:: minari.namespace.delete_namespace
+```

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -385,10 +385,10 @@ env = gym.make('CartPole-v1')
 env = DataCollector(env, record_infos=True)
 
 total_episodes = 100
-dataset_name = "cartpole-test-v0"
+dataset_id = "cartpole-test-v0"
 dataset = None
-if dataset_name in minari.list_local_datasets():
-    dataset = minari.load_dataset(dataset_name)
+if dataset_id in minari.list_local_datasets():
+    dataset = minari.load_dataset(dataset_id)
 
 for episode_id in range(total_episodes):
     env.reset()
@@ -405,7 +405,7 @@ for episode_id in range(total_episodes):
         # This works as a checkpoint to not lose the already collected data
         if dataset is None:
             dataset = env.create_dataset(
-                dataset_id=dataset_name,
+                dataset_id=dataset_id,
                 algorithm_name="Random-Policy",
                 code_permalink="https://github.com/Farama-Foundation/Minari",
                 author="Farama",
@@ -413,4 +413,13 @@ for episode_id in range(total_episodes):
             )
         else:
             env.add_to_dataset(dataset)
+```
+
+
+## Using Namespaces
+
+```{eval-rst}
+Namespaces can be used to group together common datasets and provide them with a hierarchical structure. For example, suppose we want to create a series of `Classic Control <https://gymnasium.farama.org/environments/classic_control/>`_ datasets (`cartpole`, `acrobot`, e.t.c.) using the dataset creation code above. Instead of specifying ``dataset_id=cartpole-test-v0``, we can use e.g. ``classic_control/cartpole-test-v0`` when creating the dataset. This, and all other datasets with a ``dataset_id`` that starts with ``classic_control/`` will now be stored together in the ``classic_control`` namespace.
+
+For more flexibility, namespaces can be created and modified directly using the :doc:`Namespace API <../api/namespace/namespace>`.
 ```

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -11,13 +11,17 @@ Minari stores the offline datasets under a common root directory. The root direc
 
 The remote datasets are kept in the public Google Cloud Platform (GCP) bucket [`minari-datasets`](https://console.cloud.google.com/storage/browser/minari-datasets;tab=objects?forceOnBucketsSortingFiltering=false&project=mcmes-345620&prefix=&forceOnObjectsSortingFiltering=false).
 
-The first level of the root directory tree contains the Minari dataset directories, which are named after the datasets `id`. The datasets `id` must follow the syntax `(env_name-)(dataset_name)(-v(version))`, where:
+Minari dataset directories are named after the datasets `id`. The datasets `id` must follow the syntax `(namespace/)(env_name-)(dataset_name)(-v(version))`, where:
 
+- `namespace`: an optional string that allows grouping of several datasets under a common subdirectory. If no namespace is specified (i.e. `namespace=None`), the dataset is stored in the top level directory and the dataset `id` takes the form `(env_name-)(dataset_name)(-v(version))`, with no leading forward slash. Namespaces can be arbitrarily nested.
 - `env_name`: a string that describes the environment from which the dataset was created. For example, if a dataset comes from the [`AdroitHandDoor`](https://robotics.farama.org/envs/adroit_hand/adroit_door/) environment `env_name` can be equal to `door`.
 - `dataset_name`: a string describing the content of the dataset. For example, if the dataset for the `AdroitHandDoor` environment was generated from human input we can give the value `human` to `dataset_name`.
 - `version`: integer value that represent the number of versions for `door-human-v(version)` dataset, starting from `0`.
 
-In the end, the `id` of the dataset for the initial version of the `AdroitHandDoor` environment example will be `door-human-v0`.
+In the end, the `id` of the dataset for the initial version of the `AdroitHandDoor` environment example, with no namespace, will be `door-human-v0`. If the dataset was created with a namespace, for example `D4RL`, the dataset `id` would instead be `D4RL/door-human-v0`.
+
+Minari dataset directories are stored in the root directory (`~/.minari/datasets/` by default) or in a subdirectory corresponding to the namespace of the dataset if a namespace is specified.
+
 
 ```{eval-rst}
 Each Minari dataset directory contains another directory named `data` where the data files are stored. We currently support two files format: Arrow and HDF5. You can choose the file format when you create the dataset (see :class:`minari.DataCollector` and :func:`minari.create_dataset_from_buffers`).
@@ -54,6 +58,10 @@ For each episode group the default metadata attributes are:
 | `rewards_mean` | `float` | Mean value of the episode rewards.         |
 | `rewards_std`  | `float` | Standard deviation of the episode rewards. |
 | `rewards_sum`  | `float` | Total undiscounted return of the episode.  |
+
+## Namespace metadata
+
+Namespaces can have metadata associated to them, to describe the group of datasets that they contain. Arbitrary JSON-serializable metadata is supported, and is stored in the file `namespace_metadata.json` in the appropriate namespace directory.
 
 
 ## Observation and Action Spaces

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -36,9 +36,8 @@ def _show_dataset_table(datasets: Dict[str, Dict[str, Any]], table_title: str):
 
     for dataset_id in datasets.keys():
         namespace, env_name, dataset_name, version = parse_dataset_id(dataset_id)
-        dataset_versions[gen_dataset_id(namespace, env_name, dataset_name)].append(
-            version
-        )
+        dataset_id_versionless = gen_dataset_id(namespace, env_name, dataset_name)
+        dataset_versions[dataset_id_versionless].append(version)
 
     # "Versions" column is only displayed if there are multiple versions
     display_versions = any([len(x) > 1 for x in dataset_versions.values()])

--- a/minari/cli.py
+++ b/minari/cli.py
@@ -13,7 +13,7 @@ from rich.text import Text
 from rich.tree import Tree
 
 from minari import __version__
-from minari.dataset.minari_dataset import parse_dataset_id
+from minari.dataset.minari_dataset import gen_dataset_id, parse_dataset_id
 from minari.storage import get_dataset_path, hosting, local
 from minari.utils import combine_datasets, get_dataset_spec_dict, get_env_spec_dict
 
@@ -35,8 +35,10 @@ def _show_dataset_table(datasets: Dict[str, Dict[str, Any]], table_title: str):
     dataset_versions = defaultdict(list)
 
     for dataset_id in datasets.keys():
-        env_name, dataset_name, version = parse_dataset_id(dataset_id)
-        dataset_versions[f"{env_name}-{dataset_name}"].append(version)
+        namespace, env_name, dataset_name, version = parse_dataset_id(dataset_id)
+        dataset_versions[gen_dataset_id(namespace, env_name, dataset_name)].append(
+            version
+        )
 
     # "Versions" column is only displayed if there are multiple versions
     display_versions = any([len(x) > 1 for x in dataset_versions.values()])
@@ -54,10 +56,11 @@ def _show_dataset_table(datasets: Dict[str, Dict[str, Any]], table_title: str):
     table.add_column("Dataset Size", justify="left", style="green", no_wrap=True)
     table.add_column("Author", justify="left", style="magenta", no_wrap=True)
 
+    previous_namespace = None
+
     for dataset_prefix, versions in dataset_versions.items():
         dataset_id = f"{dataset_prefix}-v{max(versions)}"
         dst_metadata = datasets[dataset_id]
-
         author = dst_metadata.get("author", "Unknown")
         if isinstance(author, Iterable):
             author = ", ".join(author)
@@ -81,6 +84,12 @@ def _show_dataset_table(datasets: Dict[str, Dict[str, Any]], table_title: str):
             dataset_id_text = f"[link={docs_url}]{dataset_id}[/link]"
         else:
             dataset_id_text = dataset_id
+
+        namespace, _, _, _ = parse_dataset_id(dataset_id)
+
+        if namespace != previous_namespace:
+            table.add_section()
+            previous_namespace = namespace
 
         # Build the current table row
         rows = []

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -16,30 +16,59 @@ from minari.dataset.minari_storage import MinariStorage, PathLike
 
 
 DATASET_ID_RE = re.compile(
-    r"(?:(?P<environment>[\w]+?))?(?:-(?P<dataset>[\w:.-]+?))(?:-v(?P<version>\d+))?$"
+    r"^(?:(?P<namespace>[-_\w][-_\w/]*[-_\w]+)\/)?(?:(?P<environment>[\w]+?))?(?:-(?P<dataset>[\w:.-]+?))(?:-v(?P<version>\d+))?$"
 )
 
 
-def parse_dataset_id(dataset_id: str) -> tuple[str | None, str, int]:
-    """Parse dataset ID string format - ``(env_name-)(dataset_name)(-v(version))``.
+def parse_dataset_id(dataset_id: str) -> tuple[str | None, str | None, str, int]:
+    """Parse dataset ID string format - ``(namespace/)(env_name-)(dataset_name)(-v(version))``.
 
     Args:
-        dataset_id: The dataset id to parse
+        dataset_id (str): The dataset id to parse
     Returns:
-        A tuple of environment name, dataset name and version number
+        A tuple of namespace, environment name, dataset name and version number
     Raises:
         Error: If the dataset id is not valid dataset regex
     """
     match = DATASET_ID_RE.fullmatch(dataset_id)
     if not match:
         raise error.Error(
-            f"Malformed dataset ID: {dataset_id}. (Currently all IDs must be of the form (env_name-)(dataset_name)-v(version). (namespace is optional))"
+            f"Malformed dataset ID: {dataset_id}. (IDs must be of the form (namespace/)(env_name-)(dataset_name)-v(version). The namespace is optional.)"
         )
-    env_name, dataset_name, version = match.group("environment", "dataset", "version")
+    namespace, env_name, dataset_name, version = match.group(
+        "namespace", "environment", "dataset", "version"
+    )
 
     version = int(version)
 
-    return env_name, dataset_name, version
+    if namespace == "":
+        namespace = None
+
+    return namespace, env_name, dataset_name, version
+
+
+def gen_dataset_id(
+    namespace: str | None,
+    env_name: str | None,
+    dataset_name: str,
+    version: int | None = None,
+) -> str:
+    """Generate a dataset ID from dataset attributes. Inverse of parse_dataset_id().
+
+    Args:
+        namespace (str | None): name of dataset subdir. Defaults to None.
+        env_name (str | None): name to identify the environment of the dataset
+        dataset_name (str): name of the dataset within the ``env_name``
+        version (int | None, optional): Dataset version. Defaults to None, in which case
+            the version tag will be suppressed.
+
+    Returns:
+        str: A dataset id string of the form ``(namespace/)(env_name-)(dataset_name)(-v(version))``.
+            The ``namespace`` and ``-v(version)`` are optional.
+    """
+    namespace_str = f"{namespace}/" if namespace is not None else ""
+    version_str = f"-v{version}" if version is not None else ""
+    return f"{namespace_str}{env_name}-{dataset_name}{version_str}"
 
 
 @dataclass
@@ -55,15 +84,19 @@ class MinariDatasetSpec:
     minari_version: str
 
     # post-init attributes
+    namespace: str | None = field(init=False)
     env_name: str | None = field(init=False)
     dataset_name: str = field(init=False)
     version: int | None = field(init=False)
 
     def __post_init__(self):
         """Calls after the spec is created to extract the environment name, dataset name and version from the dataset id."""
-        self.env_name, self.dataset_name, self.version = parse_dataset_id(
-            self.dataset_id
-        )
+        (
+            self.namespace,
+            self.env_name,
+            self.dataset_name,
+            self.version,
+        ) = parse_dataset_id(self.dataset_id)
 
 
 class MinariDataset:

--- a/minari/namespace.py
+++ b/minari/namespace.py
@@ -17,7 +17,7 @@ NAMESPACE_METADATA_FILENAME = "namespace_metadata.json"
 def create_namespace(
     namespace: str,
     description: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> None:
     """Create a local namespace.
 
@@ -31,23 +31,15 @@ def create_namespace(
     Args:
         namespace (str): identifier for namespace created/updated.
         description (str | None): string metadata describing the namespace. Defaults to None.
-        metadata (Dict[str, Any] | None): extra metadata in addition to the description. Defaults to None.
+        **kwargs: any other metadata in addition to the description.
     """
     validate_namespace(namespace)
-    metadata = {} if metadata is None else copy.deepcopy(metadata)
-
-    if description is not None:
-        if "description" not in metadata:
-            metadata["description"] = description
-
-        if description != metadata["description"]:
-            raise ValueError(
-                "Namespace description conflicts with metadata['description']."
-            )
 
     if namespace in list_local_namespaces():
         raise ValueError(f"Namespace '{namespace}' already exists.")
 
+    metadata = copy.deepcopy(kwargs)
+    metadata["description"] = description
     directory = get_dataset_path(namespace)
     os.makedirs(directory, exist_ok=True)
 
@@ -58,7 +50,7 @@ def create_namespace(
 def update_namespace_metadata(
     namespace: str,
     description: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> None:
     """Update an existing local namespace, overwriting existing namespace metadata.
 
@@ -67,24 +59,15 @@ def update_namespace_metadata(
     Args:
         namespace (str): identifier for namespace created/updated.
         description (str | None): string metadata describing the namespace. Defaults to None.
-        metadata (Dict[str, Any] | None): extra metadata in addition to the description. Defaults to None.
+        **kwargs: any other metadata in addition to the description.
     """
     validate_namespace(namespace)
 
     if namespace not in list_local_namespaces():
         raise ValueError(f"Namespace {namespace} does not exist locally.")
 
-    metadata = {} if metadata is None else copy.deepcopy(metadata)
-
-    if description is not None:
-        if "description" not in metadata:
-            metadata["description"] = description
-
-        if description != metadata["description"]:
-            raise ValueError(
-                "Namespace description conflicts with metadata['description']."
-            )
-
+    metadata = copy.deepcopy(kwargs)
+    metadata["description"] = description
     metadata_filepath = get_dataset_path(namespace) / NAMESPACE_METADATA_FILENAME
 
     with open(metadata_filepath, "w") as file:
@@ -112,7 +95,7 @@ def get_namespace_metadata(namespace: str) -> Optional[Dict[str, Any]]:
     with open(metadata_filepath) as file:
         metadata = json.load(file)
 
-    return metadata if metadata != {} else None
+    return metadata if metadata != {"description": None} else None
 
 
 def delete_namespace(namespace: str) -> None:

--- a/minari/namespace.py
+++ b/minari/namespace.py
@@ -250,7 +250,7 @@ def upload_namespace(namespace: str, key_path: str) -> None:
     namespace_metadata_path = os.path.join(namespace, NAMESPACE_METADATA_FILE_NAME)
     local_file_path = Path(get_dataset_path(""), namespace_metadata_path)
 
-    cloud_storage.upload_path(local_file_path, namespace_metadata_path)
+    cloud_storage.upload_file(local_file_path, namespace_metadata_path)
 
 
 def validate_namespace(namespace: str) -> None:

--- a/minari/namespace.py
+++ b/minari/namespace.py
@@ -1,0 +1,264 @@
+import copy
+import json
+import os
+import re
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from minari.storage import get_dataset_path
+from minari.storage.hosting import get_cloud_storage
+from minari.storage.local import list_non_hidden_dirs
+
+
+NAMESPACE_REGEX = re.compile(r"[-_\w][-_\w/]*[-_\w]+")
+NAMESPACE_METADATA_FILE_NAME = "namespace_metadata.json"
+
+
+def create_namespace(
+    namespace: str,
+    description: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    overwrite: bool = False,
+) -> None:
+    """Create or update a local namespace.
+
+    Namespaces are a directory-like structure that can contain multiple datasets, or
+    other namespaces. Namespaces are prepended onto a ``dataset_id`` with a forward
+    slash. For example a dataset with id ``my_namespace/cartpole-test-v0`` resides in
+    the ``my_namespace`` namespace. Namespaces can be nested.
+
+    Args:
+        namespace (str): identifier for namespace created/updated.
+        description (str | None): string metadata describing the namespace. Defaults to None.
+        metadata (Dict[str, Any] | None): extra metadata in addition to the description. Defaults to None.
+        overwrite (bool): whether to overwrite existing namespace data. Defaults to False.
+    """
+    validate_namespace(namespace)
+    metadata = {} if metadata is None else copy.deepcopy(metadata)
+
+    if description is not None:
+        if "description" not in metadata:
+            metadata["description"] = description
+
+        if description != metadata["description"]:
+            raise ValueError(
+                "Namespace description conflicts with metadata['description']."
+            )
+
+    namespace_exists = namespace in list_local_namespaces()
+
+    if namespace_exists:
+        existing_metadata = get_namespace_metadata(namespace)
+
+        # Recreating a namespace with the same metadata is a no-op
+        if existing_metadata == metadata:
+            return
+
+        if existing_metadata is not None and not overwrite:
+            raise ValueError(
+                f"Metadata for namespace '{namespace}' already exists. Set overwrite=True to overwrite existing metadata."
+            )
+
+    directory = os.path.join(get_dataset_path(""), namespace)
+    metadata_filepath = os.path.join(directory, NAMESPACE_METADATA_FILE_NAME)
+    os.makedirs(directory, exist_ok=True)
+
+    with open(metadata_filepath, "w") as file:
+        json.dump(metadata, file)
+
+
+def update_namespace(
+    namespace: str,
+    description: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Update an existing local namespace. Overwrites existing namespace data.
+
+    Args:
+        namespace (str): identifier for namespace created/updated.
+        description (str | None): string metadata describing the namespace. Defaults to None.
+        metadata (Dict[str, Any] | None): extra metadata in addition to the description. Defaults to None.
+    """
+    if namespace not in list_local_namespaces():
+        raise ValueError(f"Namespace {namespace} does not exist locally.")
+
+    return create_namespace(namespace, description, metadata, overwrite=True)
+
+
+def get_namespace_metadata(namespace: str) -> Optional[Dict[str, Any]]:
+    """Load local namespace metadata.
+
+    Args:
+        namespace (str): identifier for local namespace.
+
+    Returns:
+        Optional[Dict[str, Any]]: metadata dict, or None if metadata is empty.
+    """
+    validate_namespace(namespace)
+
+    if namespace not in list_local_namespaces():
+        raise ValueError(f"Namespace {namespace} does not exist locally.")
+
+    filepath = os.path.join(
+        get_dataset_path(""), namespace, NAMESPACE_METADATA_FILE_NAME
+    )
+
+    with open(filepath) as file:
+        metadata = json.load(file)
+
+    return metadata if metadata != {} else None
+
+
+def delete_namespace(namespace: str) -> None:
+    """Delete local namespace. Only empty namespaces can be deleted.
+
+    Args:
+        namespace (str): identifier for local namespace.
+    """
+    validate_namespace(namespace)
+
+    if namespace not in list_local_namespaces():
+        raise ValueError(f"Namespace '{namespace}' does not exist.")
+
+    directory = os.path.join(get_dataset_path(""), namespace)
+
+    if not os.path.isdir(directory):
+        raise FileNotFoundError(f"No namespace found at {directory}.")
+
+    dir_contents = os.listdir(directory)
+    has_metadata = NAMESPACE_METADATA_FILE_NAME in dir_contents
+
+    if len(dir_contents) != int(has_metadata):
+        raise ValueError(
+            f"Namespace {directory} is not empty. All datasets must be deleted first."
+        )
+
+    if has_metadata:
+        os.remove(os.path.join(directory, NAMESPACE_METADATA_FILE_NAME))
+
+    os.rmdir(directory)
+
+
+def list_local_namespaces() -> List[str]:
+    """Get the names of the namespaces in the local database.
+
+    Returns:
+       List[str]: names of all local namespaces.
+    """
+    datasets_path = get_dataset_path("")
+    namespaces = []
+
+    def recurse_directories(base_path, namespace):
+        parent_dir = os.path.join(base_path, namespace)
+        for dir_name in list_non_hidden_dirs(parent_dir):
+            dir_path = os.path.join(parent_dir, dir_name)
+            namespaced_dir_name = os.path.join(namespace, dir_name)
+            dir_contents = os.listdir(dir_path)
+
+            if NAMESPACE_METADATA_FILE_NAME in dir_contents:
+                namespaces.append(namespaced_dir_name)
+
+            # Don't recurse the subdirectories of a Minari dataset
+            if "data" not in dir_contents:
+                recurse_directories(base_path, namespaced_dir_name)
+
+    recurse_directories(datasets_path, "")
+
+    return sorted(namespaces)
+
+
+def list_remote_namespaces() -> List[str]:
+    """Get the names of the namespaces in the remote server.
+
+    Returns:
+       List[str]: names of all remote namespaces.
+    """
+    cloud_storage = get_cloud_storage()
+    blobs = cloud_storage.list_blobs()
+
+    remote_namespaces = []
+
+    for blob in blobs:
+        if os.path.basename(blob.name) == NAMESPACE_METADATA_FILE_NAME:
+            namespace = os.path.dirname(blob.name)
+            remote_namespaces.append(namespace)
+
+    return remote_namespaces
+
+
+def download_namespace_metadata(namespace: str, overwrite: bool = False) -> None:
+    """Download remote namespace to local database.
+
+    Args:
+        namespace (str): identifier for the remote namespace.
+        overwrite (bool): whether to overwrite existing local metadata. Defaults to False.
+    """
+    validate_namespace(namespace)
+
+    if namespace not in list_remote_namespaces():
+        raise ValueError(
+            f"The namespace '{namespace}' doesn't exist in the remote Farama server."
+        )
+
+    metadata_filename = os.path.join(namespace, NAMESPACE_METADATA_FILE_NAME)
+    cloud_storage = get_cloud_storage()
+    blobs = list(cloud_storage.list_blobs(prefix=metadata_filename))
+
+    if not blobs:
+        return
+
+    assert len(blobs) == 1
+    remote_metadata = json.loads(blobs[0].download_as_bytes(client=None))
+    local_metadata = None
+
+    if namespace in list_local_namespaces():
+        local_metadata = get_namespace_metadata(namespace)
+
+    if local_metadata != remote_metadata:
+        if overwrite or local_metadata is None:
+            create_namespace(namespace, metadata=remote_metadata, overwrite=True)
+        else:
+            warnings.warn(
+                f"Skipping update for namespace '{namespace}' due to existing local metadata. Set overwrite=True to overwrite local data.",
+                UserWarning,
+            )
+
+
+def upload_namespace(namespace: str, key_path: str) -> None:
+    """Upload a local namespace to the remote server.
+
+    If you would like to upload a namespace please first get in touch with the Farama team at contact@farama.org.
+
+    Args:
+        namespace (str): identifier for the local namespace.
+        key_path (str): path to the credentials file.
+    """
+    validate_namespace(namespace)
+
+    if namespace not in list_local_namespaces():
+        raise ValueError(f"Namespace '{namespace}' does not exist locally.")
+
+    if namespace in list_remote_namespaces():
+        print(f"Upload aborted. Namespace '{namespace}' is already in remote.")
+        return
+
+    cloud_storage = get_cloud_storage(key_path=key_path)
+
+    print(f"Uploading namespace '{namespace}'")
+
+    namespace_metadata_path = os.path.join(namespace, NAMESPACE_METADATA_FILE_NAME)
+    local_file_path = Path(get_dataset_path(""), namespace_metadata_path)
+
+    cloud_storage.upload_path(local_file_path, namespace_metadata_path)
+
+
+def validate_namespace(namespace: str) -> None:
+    if namespace is None:
+        raise TypeError("Namespace cannot be None")
+
+    if not isinstance(namespace, str):
+        raise TypeError(f"Namespace must be str, not {type(namespace)}")
+
+    if not NAMESPACE_REGEX.fullmatch(namespace):
+        raise ValueError(f"Malformed namespace: {namespace}")

--- a/minari/namespace.py
+++ b/minari/namespace.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 import warnings
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from minari.storage import get_dataset_path
@@ -12,27 +11,27 @@ from minari.storage.local import list_non_hidden_dirs
 
 
 NAMESPACE_REGEX = re.compile(r"[-_\w][-_\w/]*[-_\w]+")
-NAMESPACE_METADATA_FILE_NAME = "namespace_metadata.json"
+NAMESPACE_METADATA_FILENAME = "namespace_metadata.json"
 
 
 def create_namespace(
     namespace: str,
     description: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
-    overwrite: bool = False,
 ) -> None:
-    """Create or update a local namespace.
+    """Create a local namespace.
 
     Namespaces are a directory-like structure that can contain multiple datasets, or
     other namespaces. Namespaces are prepended onto a ``dataset_id`` with a forward
     slash. For example a dataset with id ``my_namespace/cartpole-test-v0`` resides in
     the ``my_namespace`` namespace. Namespaces can be nested.
 
+    Note: The namespace API is an experimental feature and may change in future releases.
+
     Args:
         namespace (str): identifier for namespace created/updated.
         description (str | None): string metadata describing the namespace. Defaults to None.
         metadata (Dict[str, Any] | None): extra metadata in addition to the description. Defaults to None.
-        overwrite (bool): whether to overwrite existing namespace data. Defaults to False.
     """
     validate_namespace(namespace)
     metadata = {} if metadata is None else copy.deepcopy(metadata)
@@ -46,48 +45,56 @@ def create_namespace(
                 "Namespace description conflicts with metadata['description']."
             )
 
-    namespace_exists = namespace in list_local_namespaces()
+    if namespace in list_local_namespaces():
+        raise ValueError(f"Namespace '{namespace}' already exists.")
 
-    if namespace_exists:
-        existing_metadata = get_namespace_metadata(namespace)
-
-        # Recreating a namespace with the same metadata is a no-op
-        if existing_metadata == metadata:
-            return
-
-        if existing_metadata is not None and not overwrite:
-            raise ValueError(
-                f"Metadata for namespace '{namespace}' already exists. Set overwrite=True to overwrite existing metadata."
-            )
-
-    directory = os.path.join(get_dataset_path(""), namespace)
-    metadata_filepath = os.path.join(directory, NAMESPACE_METADATA_FILE_NAME)
+    directory = get_dataset_path(namespace)
     os.makedirs(directory, exist_ok=True)
 
-    with open(metadata_filepath, "w") as file:
+    with open(directory / NAMESPACE_METADATA_FILENAME, "w") as file:
         json.dump(metadata, file)
 
 
-def update_namespace(
+def update_namespace_metadata(
     namespace: str,
     description: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Update an existing local namespace. Overwrites existing namespace data.
+    """Update an existing local namespace, overwriting existing namespace metadata.
+
+    Note: The namespace API is an experimental feature and may change in future releases.
 
     Args:
         namespace (str): identifier for namespace created/updated.
         description (str | None): string metadata describing the namespace. Defaults to None.
         metadata (Dict[str, Any] | None): extra metadata in addition to the description. Defaults to None.
     """
+    validate_namespace(namespace)
+
     if namespace not in list_local_namespaces():
         raise ValueError(f"Namespace {namespace} does not exist locally.")
 
-    return create_namespace(namespace, description, metadata, overwrite=True)
+    metadata = {} if metadata is None else copy.deepcopy(metadata)
+
+    if description is not None:
+        if "description" not in metadata:
+            metadata["description"] = description
+
+        if description != metadata["description"]:
+            raise ValueError(
+                "Namespace description conflicts with metadata['description']."
+            )
+
+    metadata_filepath = get_dataset_path(namespace) / NAMESPACE_METADATA_FILENAME
+
+    with open(metadata_filepath, "w") as file:
+        json.dump(metadata, file)
 
 
 def get_namespace_metadata(namespace: str) -> Optional[Dict[str, Any]]:
     """Load local namespace metadata.
+
+    Note: The namespace API is an experimental feature and may change in future releases.
 
     Args:
         namespace (str): identifier for local namespace.
@@ -100,11 +107,9 @@ def get_namespace_metadata(namespace: str) -> Optional[Dict[str, Any]]:
     if namespace not in list_local_namespaces():
         raise ValueError(f"Namespace {namespace} does not exist locally.")
 
-    filepath = os.path.join(
-        get_dataset_path(""), namespace, NAMESPACE_METADATA_FILE_NAME
-    )
+    metadata_filepath = get_dataset_path(namespace) / NAMESPACE_METADATA_FILENAME
 
-    with open(filepath) as file:
+    with open(metadata_filepath) as file:
         metadata = json.load(file)
 
     return metadata if metadata != {} else None
@@ -113,21 +118,21 @@ def get_namespace_metadata(namespace: str) -> Optional[Dict[str, Any]]:
 def delete_namespace(namespace: str) -> None:
     """Delete local namespace. Only empty namespaces can be deleted.
 
+    Note: The namespace API is an experimental feature and may change in future releases.
+
     Args:
         namespace (str): identifier for local namespace.
     """
     validate_namespace(namespace)
 
     if namespace not in list_local_namespaces():
-        raise ValueError(f"Namespace '{namespace}' does not exist.")
+        warnings.warn(f"Namespace '{namespace}' does not exist.", UserWarning)
+        return
 
-    directory = os.path.join(get_dataset_path(""), namespace)
-
-    if not os.path.isdir(directory):
-        raise FileNotFoundError(f"No namespace found at {directory}.")
-
+    directory = get_dataset_path(namespace)
+    assert os.path.isdir(directory)
     dir_contents = os.listdir(directory)
-    has_metadata = NAMESPACE_METADATA_FILE_NAME in dir_contents
+    has_metadata = NAMESPACE_METADATA_FILENAME in dir_contents
 
     if len(dir_contents) != int(has_metadata):
         raise ValueError(
@@ -135,13 +140,15 @@ def delete_namespace(namespace: str) -> None:
         )
 
     if has_metadata:
-        os.remove(os.path.join(directory, NAMESPACE_METADATA_FILE_NAME))
+        os.remove(directory / NAMESPACE_METADATA_FILENAME)
 
     os.rmdir(directory)
 
 
 def list_local_namespaces() -> List[str]:
     """Get the names of the namespaces in the local database.
+
+    Note: The namespace API is an experimental feature and may change in future releases.
 
     Returns:
        List[str]: names of all local namespaces.
@@ -156,7 +163,7 @@ def list_local_namespaces() -> List[str]:
             namespaced_dir_name = os.path.join(namespace, dir_name)
             dir_contents = os.listdir(dir_path)
 
-            if NAMESPACE_METADATA_FILE_NAME in dir_contents:
+            if NAMESPACE_METADATA_FILENAME in dir_contents:
                 namespaces.append(namespaced_dir_name)
 
             # Don't recurse the subdirectories of a Minari dataset
@@ -171,6 +178,8 @@ def list_local_namespaces() -> List[str]:
 def list_remote_namespaces() -> List[str]:
     """Get the names of the namespaces in the remote server.
 
+    Note: The namespace API is an experimental feature and may change in future releases.
+
     Returns:
        List[str]: names of all remote namespaces.
     """
@@ -180,7 +189,7 @@ def list_remote_namespaces() -> List[str]:
     remote_namespaces = []
 
     for blob in blobs:
-        if os.path.basename(blob.name) == NAMESPACE_METADATA_FILE_NAME:
+        if os.path.basename(blob.name) == NAMESPACE_METADATA_FILENAME:
             namespace = os.path.dirname(blob.name)
             remote_namespaces.append(namespace)
 
@@ -189,6 +198,8 @@ def list_remote_namespaces() -> List[str]:
 
 def download_namespace_metadata(namespace: str, overwrite: bool = False) -> None:
     """Download remote namespace to local database.
+
+    Note: The namespace API is an experimental feature and may change in future releases.
 
     Args:
         namespace (str): identifier for the remote namespace.
@@ -201,7 +212,7 @@ def download_namespace_metadata(namespace: str, overwrite: bool = False) -> None
             f"The namespace '{namespace}' doesn't exist in the remote Farama server."
         )
 
-    metadata_filename = os.path.join(namespace, NAMESPACE_METADATA_FILE_NAME)
+    metadata_filename = os.path.join(namespace, NAMESPACE_METADATA_FILENAME)
     cloud_storage = get_cloud_storage()
     blobs = list(cloud_storage.list_blobs(prefix=metadata_filename))
 
@@ -209,26 +220,28 @@ def download_namespace_metadata(namespace: str, overwrite: bool = False) -> None
         return
 
     assert len(blobs) == 1
-    remote_metadata = json.loads(blobs[0].download_as_bytes(client=None))
     local_metadata = None
 
     if namespace in list_local_namespaces():
         local_metadata = get_namespace_metadata(namespace)
 
-    if local_metadata != remote_metadata:
-        if overwrite or local_metadata is None:
-            create_namespace(namespace, metadata=remote_metadata, overwrite=True)
-        else:
-            warnings.warn(
-                f"Skipping update for namespace '{namespace}' due to existing local metadata. Set overwrite=True to overwrite local data.",
-                UserWarning,
-            )
+    if overwrite or local_metadata is None:
+        directory = get_dataset_path(namespace)
+        os.makedirs(directory, exist_ok=True)
+        blobs[0].download_to_filename(directory / NAMESPACE_METADATA_FILENAME)
+    else:
+        warnings.warn(
+            f"Skipping update for namespace '{namespace}' due to existing local metadata. Set overwrite=True to overwrite local data.",
+            UserWarning,
+        )
 
 
 def upload_namespace(namespace: str, key_path: str) -> None:
     """Upload a local namespace to the remote server.
 
     If you would like to upload a namespace please first get in touch with the Farama team at contact@farama.org.
+
+    Note: The namespace API is an experimental feature and may change in future releases.
 
     Args:
         namespace (str): identifier for the local namespace.
@@ -240,25 +253,31 @@ def upload_namespace(namespace: str, key_path: str) -> None:
         raise ValueError(f"Namespace '{namespace}' does not exist locally.")
 
     if namespace in list_remote_namespaces():
-        print(f"Upload aborted. Namespace '{namespace}' is already in remote.")
+        warnings.warn(
+            f"Upload aborted. Namespace '{namespace}' is already in remote.",
+            UserWarning,
+        )
         return
 
     cloud_storage = get_cloud_storage(key_path=key_path)
 
     print(f"Uploading namespace '{namespace}'")
 
-    namespace_metadata_path = os.path.join(namespace, NAMESPACE_METADATA_FILE_NAME)
-    local_file_path = Path(get_dataset_path(""), namespace_metadata_path)
+    local_filepath = get_dataset_path(namespace) / NAMESPACE_METADATA_FILENAME
+    remote_filepath = os.path.join(namespace, NAMESPACE_METADATA_FILENAME)
+    cloud_storage.upload_file(local_filepath, remote_filepath)
 
-    cloud_storage.upload_file(local_file_path, namespace_metadata_path)
 
+def validate_namespace(namespace: Optional[str]) -> None:
+    """Validate a namespace identifier.
 
-def validate_namespace(namespace: str) -> None:
+    Note: The namespace API is an experimental feature and may change in future releases.
+
+    Args:
+        namespace (str | None): identifier to validate
+    """
     if namespace is None:
         raise TypeError("Namespace cannot be None")
-
-    if not isinstance(namespace, str):
-        raise TypeError(f"Namespace must be str, not {type(namespace)}")
 
     if not NAMESPACE_REGEX.fullmatch(namespace):
         raise ValueError(f"Malformed namespace: {namespace}")

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -33,7 +33,9 @@ def upload_dataset(dataset_id: str, key_path: str):
 
     remote_datasets = list_remote_datasets()
     if dataset_id in remote_datasets.keys():
-        print(f"Upload aborted. {dataset_id} is already in remote.")
+        warnings.warn(
+            f"Upload aborted. {dataset_id} is already in remote.", UserWarning
+        )
         return
 
     cloud_storage = get_cloud_storage(key_path=key_path)
@@ -66,6 +68,9 @@ def download_dataset(dataset_id: str, force_download: bool = False):
         dataset_id (str): name id of the Minari dataset
         force_download (bool): boolean flag for force downloading the dataset. Default Value = False
     """
+    # Avoid circular import
+    from minari.namespace import create_namespace, list_local_namespaces
+
     (
         namespace,
         env_name,
@@ -155,6 +160,9 @@ def download_dataset(dataset_id: str, force_download: bool = False):
                 f"Skipping Download. Dataset {dataset_id} found locally at {file_path}, Use force_download=True to download the dataset again.\n"
             )
             return
+
+    if namespace is not None and namespace not in list_local_namespaces():
+        create_namespace(namespace)
 
     print(f"\nDownloading {dataset_id} from Farama servers...")
     datasets_path = get_dataset_path("")

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -229,13 +229,6 @@ def list_remote_datasets(
                 ):
                     continue
                 dataset_id = metadata["dataset_id"]
-                dataset_location = os.path.dirname(os.path.dirname(blob.name))
-
-                if dataset_id != dataset_location:
-                    raise ValueError(
-                        f"Namespace location '{dataset_location}' does not match id '{dataset_id}'."
-                    )
-
                 namespace, env_name, dataset_name, version = parse_dataset_id(
                     dataset_id
                 )

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -8,10 +8,10 @@ from typing import Dict, List
 
 from gymnasium import logger
 
-from minari.dataset.minari_dataset import parse_dataset_id
+from minari.dataset.minari_dataset import gen_dataset_id, parse_dataset_id
 from minari.dataset.minari_storage import METADATA_FILE_NAME
 from minari.storage.datasets_root_dir import get_dataset_path
-from minari.storage.local import load_dataset
+from minari.storage.local import dataset_id_sort_key, load_dataset
 from minari.storage.remotes import get_cloud_storage
 
 
@@ -40,7 +40,7 @@ def upload_dataset(dataset_id: str, key_path: str):
         dataset_id = datasets_to_upload.pop()
         print(f"Uploading dataset {dataset_id}")
         path = get_dataset_path(dataset_id)
-        cloud_storage.upload_path(path, dataset_id)
+        cloud_storage.upload_directory(path, dataset_id)
         dataset = load_dataset(dataset_id)
         combined_datasets = dataset.spec.combined_datasets
         datasets_to_upload.extend(combined_datasets)
@@ -57,18 +57,28 @@ def download_dataset(dataset_id: str, force_download: bool = False):
         dataset_id (str): name id of the Minari dataset
         force_download (bool): boolean flag for force downloading the dataset. Default Value = False
     """
-    env_name, dataset_name, dataset_version = parse_dataset_id(dataset_id)
+    (
+        namespace,
+        env_name,
+        dataset_name,
+        dataset_version,
+    ) = parse_dataset_id(dataset_id)
 
-    all_dataset_versions = get_remote_dataset_versions(env_name, dataset_name)
+    all_dataset_versions = get_remote_dataset_versions(
+        namespace, env_name, dataset_name
+    )
+
+    dataset_versionless = gen_dataset_id(namespace, env_name, dataset_name)
 
     # 1. Check if there are any remote versions of the dataset at all
     if not all_dataset_versions:
         raise ValueError(
-            f"Couldn't find any version for dataset {env_name}-{dataset_name} in the remote Farama server."
+            f"Couldn't find any version for dataset {dataset_versionless} in the remote Farama server."
         )
 
     # 2. Check if there are any remote compatible versions with the local installed Minari version
     max_version = get_remote_dataset_versions(
+        namespace,
         env_name,
         dataset_name,
         latest_version=True,
@@ -77,11 +87,11 @@ def download_dataset(dataset_id: str, force_download: bool = False):
     if not max_version:
         if not force_download:
             raise ValueError(
-                f"Couldn't find any compatible version of dataset {env_name}-{dataset_name} with the local installed version of Minari, {__version__}."
+                f"Couldn't find any compatible version of dataset {dataset_versionless} with the local installed version of Minari, {__version__}."
             )
         else:
             logger.warn(
-                f"Couldn't find any compatible version of dataset {env_name}-{dataset_name} with the local installed version of Minari, {__version__}."
+                f"Couldn't find any compatible version of dataset {dataset_versionless} with the local installed version of Minari, {__version__}."
             )
 
     # 3. Check that the dataset version exists
@@ -95,11 +105,12 @@ def download_dataset(dataset_id: str, force_download: bool = False):
         else:
             raise ValueError(
                 e_msg
-                + f" We suggest you download the latest compatible version of this dataset: {env_name}-{dataset_name}-v{max_version[0]}"
+                + f" We suggest you download the latest compatible version of this dataset: {dataset_versionless}-v{max_version[0]}"
             )
 
     # 4. Check that the dataset version is compatible with the local installed Minari version
     compatible_dataset_versions = get_remote_dataset_versions(
+        namespace,
         env_name,
         dataset_name,
         latest_version=False,
@@ -113,19 +124,19 @@ def download_dataset(dataset_id: str, force_download: bool = False):
         if not force_download:
             raise ValueError(
                 e_msg
-                + f" You can download the latest compatible version of this dataset: {env_name}-{dataset_name}-v{max_version[0]}."
+                + f" You can download the latest compatible version of this dataset: {dataset_versionless}-v{max_version[0]}."
             )
         # Only a warning and force download incompatible dataset
         else:
             logger.warn(
                 e_msg
-                + f" {dataset_id} will be FORCE download but you can download the latest compatible version of this dataset: {env_name}-{dataset_name}-v{max_version}."
+                + f" {dataset_id} will be FORCE download but you can download the latest compatible version of this dataset: {dataset_versionless}-v{max_version}."
             )
 
     # 5. Warning to recommend downloading the latest compatible version of the dataset
     elif max_version[0] is not None and dataset_version < max_version[0]:
         logger.warn(
-            f"We recommend you install a higher dataset version available and compatible with your local installed Minari version: {env_name}-{dataset_name}-v{max_version}."
+            f"We recommend you install a higher dataset version available and compatible with your local installed Minari version: {dataset_versionless}-v{max_version}."
         )
 
     file_path = get_dataset_path(dataset_id)
@@ -137,6 +148,7 @@ def download_dataset(dataset_id: str, force_download: bool = False):
             return
 
     print(f"\nDownloading {dataset_id} from Farama servers...")
+    datasets_path = get_dataset_path("")
     cloud_storage = get_cloud_storage()
     blobs = cloud_storage.list_blobs(prefix=dataset_id)
 
@@ -147,7 +159,7 @@ def download_dataset(dataset_id: str, force_download: bool = False):
             file_name == ""
         ):  # If the object blob path is a directory continue searching for files
             continue
-        blob_local_dir = os.path.join(os.path.dirname(file_path), blob_dir)
+        blob_local_dir = os.path.join(datasets_path, blob_dir)
         if not os.path.exists(blob_local_dir):
             os.makedirs(blob_local_dir)
         cloud_storage.download_blob(blob, os.path.join(blob_local_dir, file_name))
@@ -188,11 +200,11 @@ def list_remote_datasets(
     cloud_storage = get_cloud_storage()
     blobs = cloud_storage.list_blobs()
 
-    # Generate dict = {'env_name-dataset_name': (version, metadata)}
+    # Generate dict = {'namespace/env_name-dataset_name': (version, metadata)}
     remote_datasets = {}
     for blob in blobs:
         try:
-            if blob.name.endswith(METADATA_FILE_NAME):
+            if os.path.basename(blob.name) == METADATA_FILE_NAME:
                 metadata = json.loads(blob.download_as_bytes(client=None))
                 if (
                     compatible_minari_version
@@ -200,8 +212,10 @@ def list_remote_datasets(
                 ):
                     continue
                 dataset_id = metadata["dataset_id"]
-                env_name, dataset_name, version = parse_dataset_id(dataset_id)
-                dataset = f"{env_name}-{dataset_name}"
+                namespace, env_name, dataset_name, version = parse_dataset_id(
+                    dataset_id
+                )
+                dataset = gen_dataset_id(namespace, env_name, dataset_name)
                 if latest_version:
                     if (
                         dataset not in remote_datasets
@@ -214,15 +228,18 @@ def list_remote_datasets(
             warnings.warn(f"Misconfigured dataset named {blob.name} on remote")
 
     if latest_version:
-        # Return dict = {'dataset_id': metadata}
-        return dict(
+        # Convert to dict = {'dataset_id': metadata}
+        remote_datasets = dict(
             map(lambda x: (f"{x[0]}-v{x[1][0]}", x[1][1]), remote_datasets.items())
         )
-    else:
-        return remote_datasets
+
+    return {
+        k: remote_datasets[k] for k in sorted(remote_datasets, key=dataset_id_sort_key)
+    }
 
 
 def get_remote_dataset_versions(
+    namespace: str | None,
     env_name: str | None,
     dataset_name: str,
     latest_version: bool = False,
@@ -231,7 +248,8 @@ def get_remote_dataset_versions(
     """Finds all registered versions in the remote Farama server of the dataset given.
 
     Args:
-        env_name (str): name to identigy the environment of the dataset
+        namespace (str | None): identifier for remote namespace. Defaults to None.
+        env_name (str | None): name to identify the environment of the dataset
         dataset_name (str): name of the dataset within the ``env_name``
         latest_version (bool): if `True` only the latest version of the datasets is returned. Default to `False`.
         compatible_minari_version: only return highest version among the datasets compatible with the local installed version of Minari. Default to `False`
@@ -243,11 +261,18 @@ def get_remote_dataset_versions(
     for dataset_id in list_remote_datasets(
         latest_version, compatible_minari_version
     ).keys():
-        remote_env_name, remote_dataset_name, remote_version = parse_dataset_id(
-            dataset_id
-        )
+        (
+            remote_namespace,
+            remote_env_name,
+            remote_dataset_name,
+            remote_version,
+        ) = parse_dataset_id(dataset_id)
 
-        if remote_env_name == env_name and remote_dataset_name == dataset_name:
+        if (
+            remote_namespace == namespace
+            and remote_env_name == env_name
+            and remote_dataset_name == dataset_name
+        ):
             versions.append(remote_version)
 
     return versions

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -93,6 +93,12 @@ def list_local_datasets(
         data_path = os.path.join(datasets_path, dst_id, "data")
         try:
             metadata = MinariStorage.read(data_path).metadata
+            metadata_id = metadata["dataset_id"]
+
+            if dst_id != metadata_id:
+                raise ValueError(
+                    f"Namespace location '{dst_id}' does not match id '{metadata_id}'."
+                )
         except Exception as e:
             warnings.warn(f"Misconfigured dataset named {dst_id}: {e}")
             continue

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -2,9 +2,13 @@ import importlib.metadata
 import os
 import shutil
 import warnings
-from typing import Dict, Union
+from typing import Dict, List, Tuple, Union
 
-from minari.dataset.minari_dataset import MinariDataset, parse_dataset_id
+from minari.dataset.minari_dataset import (
+    MinariDataset,
+    gen_dataset_id,
+    parse_dataset_id,
+)
 from minari.dataset.minari_storage import MinariStorage
 from minari.storage import hosting
 from minari.storage.datasets_root_dir import get_dataset_path
@@ -12,6 +16,19 @@ from minari.storage.datasets_root_dir import get_dataset_path
 
 # Use importlib due to circular import when: "from minari import __version__"
 __version__ = importlib.metadata.version("minari")
+
+
+def list_non_hidden_dirs(path: str) -> List[str]:
+    """List all non-hidden subdirectories."""
+    return [
+        d.name for d in os.scandir(path) if d.is_dir() and (not d.name.startswith("."))
+    ]
+
+
+def dataset_id_sort_key(dataset_id: str) -> Tuple[str, Union[str, None], str, int]:
+    """Key for sorting dataset ids first by namespace, and then alphabetically."""
+    attrs = parse_dataset_id(dataset_id)
+    return ("" if attrs[0] is None else attrs[0],) + attrs[1:]
 
 
 def load_dataset(dataset_id: str, download: bool = False):
@@ -54,20 +71,25 @@ def list_local_datasets(
     from minari import supported_dataset_versions
 
     datasets_path = get_dataset_path("")
-    dataset_ids = sorted(
-        [
-            dir_name
-            for dir_name in os.listdir(datasets_path)
-            if not dir_name.startswith(".")
-        ]
-    )
+    dataset_ids = []
+
+    def recurse_directories(base_path, namespace):
+        parent_dir = os.path.join(base_path, namespace)
+        for dir_name in list_non_hidden_dirs(parent_dir):
+            dir_path = os.path.join(parent_dir, dir_name)
+            namespaced_dir_name = os.path.join(namespace, dir_name)
+            # Minari datasets must contain the data directory.
+            if "data" in os.listdir(dir_path):
+                dataset_ids.append(namespaced_dir_name)
+            else:
+                recurse_directories(base_path, namespaced_dir_name)
+
+    recurse_directories(datasets_path, "")
+
+    dataset_ids = sorted(dataset_ids, key=dataset_id_sort_key)
 
     local_datasets = {}
     for dst_id in dataset_ids:
-        if "data" not in os.listdir(os.path.join(datasets_path, dst_id)):
-            # Minari datasets must contain the data directory.
-            continue
-
         data_path = os.path.join(datasets_path, dst_id, "data")
         try:
             metadata = MinariStorage.read(data_path).metadata
@@ -81,8 +103,9 @@ def list_local_datasets(
         ):
             continue
 
-        env_name, dataset_name, version = parse_dataset_id(dst_id)
-        dataset = f"{env_name}-{dataset_name}"
+        namespace, env_name, dataset_name, version = parse_dataset_id(dst_id)
+        dataset = gen_dataset_id(namespace, env_name, dataset_name)
+
         if latest_version:
             if dataset not in local_datasets or version > local_datasets[dataset][0]:
                 local_datasets[dataset] = (version, metadata)

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -27,8 +27,10 @@ def list_non_hidden_dirs(path: str) -> Iterable[str]:
 
 def dataset_id_sort_key(dataset_id: str) -> Tuple[str, Union[str, None], str, int]:
     """Key for sorting dataset ids first by namespace, and then alphabetically."""
-    attrs = parse_dataset_id(dataset_id)
-    return ("" if attrs[0] is None else attrs[0],) + attrs[1:]
+    namespace, env_name, dataset_name, version = parse_dataset_id(dataset_id)
+    namespace = "" if namespace is None else namespace
+    env_name = "" if env_name is None else env_name
+    return (namespace, env_name, dataset_name, version)
 
 
 def load_dataset(dataset_id: str, download: bool = False):

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -2,7 +2,7 @@ import importlib.metadata
 import os
 import shutil
 import warnings
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterable, Tuple, Union
 
 from minari.dataset.minari_dataset import (
     MinariDataset,
@@ -18,11 +18,11 @@ from minari.storage.datasets_root_dir import get_dataset_path
 __version__ = importlib.metadata.version("minari")
 
 
-def list_non_hidden_dirs(path: str) -> List[str]:
+def list_non_hidden_dirs(path: str) -> Iterable[str]:
     """List all non-hidden subdirectories."""
-    return [
-        d.name for d in os.scandir(path) if d.is_dir() and (not d.name.startswith("."))
-    ]
+    for d in os.scandir(path):
+        if d.is_dir() and (not d.name.startswith(".")):
+            yield d.name
 
 
 def dataset_id_sort_key(dataset_id: str) -> Tuple[str, Union[str, None], str, int]:

--- a/minari/storage/remotes/cloud_storage.py
+++ b/minari/storage/remotes/cloud_storage.py
@@ -13,7 +13,7 @@ class CloudStorage(ABC):
         ...
 
     @abstractmethod
-    def upload_path(self, local_path: Path, remote_path: str) -> None:
+    def upload_file(self, local_path: Path, remote_path: str) -> None:
         ...
 
     @abstractmethod

--- a/minari/storage/remotes/cloud_storage.py
+++ b/minari/storage/remotes/cloud_storage.py
@@ -9,7 +9,11 @@ class CloudStorage(ABC):
         ...
 
     @abstractmethod
-    def upload_path(self, path: Path, dataset_id: str) -> None:
+    def upload_directory(self, path: Path, remote_dir_path: str) -> None:
+        ...
+
+    @abstractmethod
+    def upload_path(self, local_path: Path, remote_path: str) -> None:
         ...
 
     @abstractmethod

--- a/minari/storage/remotes/gcp.py
+++ b/minari/storage/remotes/gcp.py
@@ -28,7 +28,6 @@ class GCPStorage(CloudStorage):
             else:
                 remote_path = os.path.join(remote_dir_path, local_file.name)
                 self.upload_file(local_file, remote_path)
-                print("Uploaded", local_file, "to", remote_path)
 
     def upload_file(self, local_path: Path, remote_path: str) -> None:
         blob = self.bucket.blob(remote_path)

--- a/minari/storage/remotes/gcp.py
+++ b/minari/storage/remotes/gcp.py
@@ -18,17 +18,21 @@ class GCPStorage(CloudStorage):
             )
         self.bucket = storage.Bucket(self.storage_client, name)
 
-    def upload_path(self, path: Path, dataset_id: str) -> None:
+    def upload_directory(self, path: Path, remote_dir_path: str) -> None:
         # See https://github.com/googleapis/python-storage/issues/27 for discussion on progress bars
-        for local_file in path.glob("**"):
-            if not os.path.isfile(local_file):
-                self.upload_path(
-                    local_file, dataset_id + "/" + os.path.basename(local_file)
+        for local_file in path.glob("*"):
+            if local_file.is_dir():
+                self.upload_directory(
+                    local_file, remote_dir_path + "/" + os.path.basename(local_file)
                 )
             else:
-                remote_path = os.path.join(dataset_id, local_file.name)
-                blob = self.bucket.blob(remote_path)
-                blob.upload_from_filename(local_file)
+                remote_path = os.path.join(remote_dir_path, local_file.name)
+                self.upload_path(local_file, remote_path)
+                print("Uploaded", local_file, "to", remote_path)
+
+    def upload_path(self, local_path: Path, remote_path: str) -> None:
+        blob = self.bucket.blob(remote_path)
+        blob.upload_from_filename(local_path)
 
     def list_blobs(self, prefix: Optional[str] = None) -> list:
         return self.bucket.list_blobs(prefix=prefix)

--- a/minari/storage/remotes/gcp.py
+++ b/minari/storage/remotes/gcp.py
@@ -27,10 +27,10 @@ class GCPStorage(CloudStorage):
                 )
             else:
                 remote_path = os.path.join(remote_dir_path, local_file.name)
-                self.upload_path(local_file, remote_path)
+                self.upload_file(local_file, remote_path)
                 print("Uploaded", local_file, "to", remote_path)
 
-    def upload_path(self, local_path: Path, remote_path: str) -> None:
+    def upload_file(self, local_path: Path, remote_path: str) -> None:
         blob = self.bucket.blob(remote_path)
         blob.upload_from_filename(local_path)
 

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -347,7 +347,7 @@ def create_dataset_from_buffers(
     """Create Minari dataset from a list of episode dictionary buffers.
 
     The ``dataset_id`` parameter corresponds to the name of the dataset, with the syntax as follows:
-    ``(env_name-)(dataset_name)(-v(version))`` where ``env_name`` identifies the name of the environment used to generate the dataset ``dataset_name``.
+    ``(namespace/)(env_name-)(dataset_name)(-v(version))`` where ``env_name`` identifies the name of the environment used to generate the dataset ``dataset_name`` and ``namespace`` optionally groups datasets together.
     This ``dataset_id`` is used to load the Minari datasets with :meth:`minari.load_dataset`.
 
     Args:

--- a/tests/common.py
+++ b/tests/common.py
@@ -29,6 +29,7 @@ dummy_test_datasets = [
     ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
     ("dummy-combo-test-v0", "DummyComboEnv-v0"),
     ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
+    ("nested/namespace/dummy-dict-test-v0", "DummyDictEnv-v0"),
 ] + dummy_box_dataset
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,7 +10,9 @@ from gymnasium.utils.env_checker import data_equivalence
 import minari
 from minari import DataCollector, EpisodeData, MinariDataset, StepData
 from minari.data_collector import EpisodeBuffer
+from minari.dataset.minari_dataset import gen_dataset_id
 from minari.dataset.minari_storage import MinariStorage
+from minari.storage.hosting import get_remote_dataset_versions
 
 
 unicode_charset = "".join(
@@ -724,3 +726,23 @@ def get_sample_buffer_for_dataset_from_env(env: gym.Env, num_episodes: int = 10)
         episode_buffer = EpisodeBuffer(observations=observation)
 
     return buffer
+
+
+def get_latest_compatible_dataset_id(namespace, env_name, dataset_name):
+    latest_compatible_versions = get_remote_dataset_versions(
+        namespace=namespace,
+        env_name=env_name,
+        dataset_name=dataset_name,
+        latest_version=True,
+        compatible_minari_version=True,
+    )
+
+    if len(latest_compatible_versions) == 0:
+        raise ValueError(
+            f"No datasets of the form '{gen_dataset_id(namespace, env_name, dataset_name)}' exist in the remote Farama server."
+        )
+
+    assert len(latest_compatible_versions) == 1
+    return gen_dataset_id(
+        namespace, env_name, dataset_name, latest_compatible_versions[0]
+    )

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,6 +17,18 @@ unicode_charset = "".join(
     [chr(i) for i in range(sys.maxunicode) if unicodedata.category(chr(i)) != "Cs"]
 )
 
+cartpole_test_dataset = [("cartpole-test-v0", "CartPole-v1")]
+dummy_box_dataset = [("dummy-box-test-v0", "DummyBoxEnv-v0")]
+dummy_text_dataset = [("dummy-text-test-v0", "DummyTextEnv-v0")]
+
+# Note: Doesn't include the text dataset, since this is often handled separately
+dummy_test_datasets = [
+    ("dummy-dict-test-v0", "DummyDictEnv-v0"),
+    ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
+    ("dummy-combo-test-v0", "DummyComboEnv-v0"),
+    ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
+] + dummy_box_dataset
+
 
 class DummyBoxEnv(gym.Env):
     def __init__(self):
@@ -600,10 +612,6 @@ def check_load_and_delete_dataset(dataset_id: str):
 def create_dummy_dataset_with_collecter_env_helper(
     dataset_id: str, env: DataCollector, num_episodes: int = 10, **kwargs
 ):
-    local_datasets = minari.list_local_datasets()
-    if dataset_id in local_datasets:
-        minari.delete_dataset(dataset_id)
-
     # Step the environment, DataCollector wrapper will do the data collection job
     env.reset(seed=42)
 

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -7,6 +7,7 @@ from minari.dataset._storages import registry as storage_registry
 from tests.common import (
     check_infos_equal,
     check_load_and_delete_dataset,
+    dummy_test_datasets,
     get_info_at_step_index,
 )
 
@@ -92,16 +93,7 @@ def get_single_step_from_episode(episode: EpisodeData, index: int) -> EpisodeDat
 
 
 @pytest.mark.parametrize("data_format", storage_registry.keys())
-@pytest.mark.parametrize(
-    "dataset_id,env_id",
-    [
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
-)
+@pytest.mark.parametrize("dataset_id,env_id", dummy_test_datasets)
 def test_truncation_without_reset(dataset_id, env_id, data_format, register_dummy_envs):
     """Test new episode creation when environment is truncated and env.reset is not called."""
     num_steps = 50

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -4,6 +4,8 @@ import pytest
 
 from minari import DataCollector, EpisodeData, MinariDataset, StepDataCallback
 from minari.dataset._storages import registry as storage_registry
+from minari.dataset.minari_dataset import parse_dataset_id
+from minari.namespace import get_namespace_metadata, list_local_namespaces
 from tests.common import (
     check_infos_equal,
     check_load_and_delete_dataset,
@@ -93,7 +95,10 @@ def get_single_step_from_episode(episode: EpisodeData, index: int) -> EpisodeDat
 
 
 @pytest.mark.parametrize("data_format", storage_registry.keys())
-@pytest.mark.parametrize("dataset_id,env_id", dummy_test_datasets)
+@pytest.mark.parametrize(
+    "dataset_id,env_id",
+    dummy_test_datasets + [("nested_123/name-space/cartpole-test-v0", "CartPole-v1")],
+)
 def test_truncation_without_reset(dataset_id, env_id, data_format, register_dummy_envs):
     """Test new episode creation when environment is truncated and env.reset is not called."""
     num_steps = 50
@@ -126,6 +131,8 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
     assert dataset.spec.total_episodes == num_episodes
     assert len(dataset.episode_indices) == num_episodes
 
+    assert dataset.spec.namespace == parse_dataset_id(dataset_id)[0]
+
     episodes_generator = dataset.iterate_episodes()
     last_step = get_single_step_from_episode(next(episodes_generator), -1)
     for episode in episodes_generator:
@@ -143,6 +150,11 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
         check_infos_equal(last_step.infos, first_step.infos)
         last_step = get_single_step_from_episode(episode, -1)
         assert bool(last_step.truncations) is True
+
+    if "/" in dataset_id:
+        namespace, _, _, _ = parse_dataset_id(dataset_id)
+        assert namespace in list_local_namespaces()
+        assert get_namespace_metadata(namespace) is None
 
     # check load and delete local dataset
     check_load_and_delete_dataset(dataset_id)

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -95,10 +95,7 @@ def get_single_step_from_episode(episode: EpisodeData, index: int) -> EpisodeDat
 
 
 @pytest.mark.parametrize("data_format", storage_registry.keys())
-@pytest.mark.parametrize(
-    "dataset_id,env_id",
-    dummy_test_datasets + [("nested_123/name-space/cartpole-test-v0", "CartPole-v1")],
-)
+@pytest.mark.parametrize("dataset_id,env_id", dummy_test_datasets)
 def test_truncation_without_reset(dataset_id, env_id, data_format, register_dummy_envs):
     """Test new episode creation when environment is truncated and env.reset is not called."""
     num_steps = 50

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -13,11 +13,13 @@ from minari.data_collector.episode_buffer import EpisodeBuffer
 from minari.dataset._storages import registry as storage_registry
 from minari.dataset.minari_storage import METADATA_FILE_NAME
 from tests.common import (
+    cartpole_test_dataset,
     check_data_integrity,
     check_env_recovery,
     check_episode_data_integrity,
     check_load_and_delete_dataset,
     create_dummy_dataset_with_collecter_env_helper,
+    dummy_test_datasets,
     test_spaces,
 )
 
@@ -58,15 +60,7 @@ def test_episode_data(space: gym.Space):
 
 
 @pytest.mark.parametrize(
-    "dataset_id,env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
+    "dataset_id,env_id", cartpole_test_dataset + dummy_test_datasets
 )
 @pytest.mark.parametrize("data_format", storage_registry.keys())
 def test_update_dataset_from_collector_env(
@@ -113,16 +107,7 @@ def test_update_dataset_from_collector_env(
     check_load_and_delete_dataset(dataset_id)
 
 
-@pytest.mark.parametrize(
-    "dataset_id,env_id",
-    [
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
-)
+@pytest.mark.parametrize("dataset_id,env_id", dummy_test_datasets)
 @pytest.mark.parametrize("data_format", storage_registry.keys())
 def test_filter_episodes_and_subsequent_updates(
     dataset_id, env_id, data_format, register_dummy_envs
@@ -278,15 +263,7 @@ def test_filter_episodes_and_subsequent_updates(
 
 
 @pytest.mark.parametrize(
-    "dataset_id,env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
+    "dataset_id,env_id", cartpole_test_dataset + dummy_test_datasets
 )
 @pytest.mark.parametrize("data_format", storage_registry.keys())
 def test_sample_episodes(dataset_id, env_id, data_format, register_dummy_envs):
@@ -322,15 +299,7 @@ def test_sample_episodes(dataset_id, env_id, data_format, register_dummy_envs):
 
 
 @pytest.mark.parametrize(
-    "dataset_id, env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
+    "dataset_id,env_id", cartpole_test_dataset + dummy_test_datasets
 )
 @pytest.mark.parametrize("data_format", storage_registry.keys())
 def test_iterate_episodes(dataset_id, env_id, data_format, register_dummy_envs):
@@ -371,15 +340,7 @@ def test_iterate_episodes(dataset_id, env_id, data_format, register_dummy_envs):
 
 
 @pytest.mark.parametrize(
-    "dataset_id,env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
+    "dataset_id,env_id", cartpole_test_dataset + dummy_test_datasets
 )
 @pytest.mark.parametrize("data_format", storage_registry.keys())
 def test_update_dataset_from_buffer(

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -11,6 +11,7 @@ import minari
 from minari import DataCollector, EpisodeData, MinariDataset, StepData
 from minari.data_collector.episode_buffer import EpisodeBuffer
 from minari.dataset._storages import registry as storage_registry
+from minari.dataset.minari_dataset import gen_dataset_id, parse_dataset_id
 from minari.dataset.minari_storage import METADATA_FILE_NAME
 from tests.common import (
     cartpole_test_dataset,
@@ -438,3 +439,30 @@ def test_missing_env_module(data_format):
         dataset.recover_environment()
 
     minari.delete_dataset(dataset_id)
+
+
+@pytest.mark.parametrize(
+    "dataset_id",
+    [x[0] for x in dummy_test_datasets]
+    + ["name_123/space/" + x[0] for x in dummy_test_datasets],
+)
+def test_parse_gen_dataset_id_inverse_forward(dataset_id):
+    """Check parse_dataset_id() and gen_dataset_id() are inverses. Forward direction."""
+    namespace, env_name, dataset_name, version = parse_dataset_id(dataset_id)
+    new_dataset_id = gen_dataset_id(namespace, env_name, dataset_name, version)
+    assert new_dataset_id == dataset_id
+
+
+@pytest.mark.parametrize(
+    "namespace, env_name, dataset_name, version",
+    [
+        (None, "door", "human", 0),
+        ("aB1-_", "cD2", "eF3:.-_", 456),
+    ],
+)
+def test_parse_gen_dataset_id_inverse_backward(
+    namespace, env_name, dataset_name, version
+):
+    """Check parse_dataset_id() and gen_dataset_id() are inverses. Backward direction."""
+    attrs = (namespace, env_name, dataset_name, version)
+    assert attrs == parse_dataset_id(gen_dataset_id(*attrs))

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -12,7 +12,13 @@ from minari.data_collector.callbacks.step_callback import StepData
 from minari.data_collector.episode_buffer import EpisodeBuffer
 from minari.dataset._storages import registry as storage_registry
 from minari.dataset.minari_storage import MinariStorage
-from tests.common import check_data_integrity, check_load_and_delete_dataset
+from tests.common import (
+    cartpole_test_dataset,
+    check_data_integrity,
+    check_load_and_delete_dataset,
+    dummy_test_datasets,
+    dummy_text_dataset,
+)
 
 
 file_path = os.path.join(os.path.expanduser("~"), ".minari", "datasets")
@@ -177,18 +183,10 @@ def test_episode_metadata(tmp_dataset_dir, data_format):
     storage.update_episode_metadata(ep_metadatas, episode_indices=ep_indices)
 
 
-@pytest.mark.parametrize(
-    "dataset_id,env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
-)
 @pytest.mark.parametrize("data_format", storage_registry.keys())
+@pytest.mark.parametrize(
+    "dataset_id,env_id", cartpole_test_dataset + dummy_test_datasets
+)
 def test_minari_get_dataset_size_from_collector_env(
     dataset_id, env_id, data_format, register_dummy_envs
 ):
@@ -233,19 +231,11 @@ def test_minari_get_dataset_size_from_collector_env(
     check_load_and_delete_dataset(dataset_id)
 
 
+@pytest.mark.parametrize("data_format", storage_registry.keys())
 @pytest.mark.parametrize(
     "dataset_id,env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-text-test-v0", "DummyTextEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
+    cartpole_test_dataset + dummy_test_datasets + dummy_text_dataset,
 )
-@pytest.mark.parametrize("data_format", storage_registry.keys())
 def test_minari_get_dataset_size_from_buffer(
     dataset_id, env_id, data_format, register_dummy_envs
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,11 @@ def test_list_app():
 
 @pytest.mark.parametrize(
     "dataset_id",
-    [get_latest_compatible_dataset_id(env_name="pen", dataset_name="human")],
+    [
+        get_latest_compatible_dataset_id(
+            namespace=None, env_name="pen", dataset_name="human"
+        )
+    ],
 )
 def test_dataset_download_then_delete(dataset_id: str):
     """Test download dataset invocation from CLI.

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,122 @@
+import gymnasium as gym
+import pytest
+
+from minari import list_local_datasets
+from minari.data_collector.data_collector import DataCollector
+from minari.namespace import (
+    create_namespace,
+    delete_namespace,
+    get_namespace_metadata,
+    list_local_namespaces,
+    update_namespace,
+)
+from tests.common import (
+    check_load_and_delete_dataset,
+    create_dummy_dataset_with_collecter_env_helper,
+)
+
+
+@pytest.mark.parametrize(
+    "namespace",
+    [
+        "example_-123",
+        "nested/nested/nested/namespace",
+    ],
+)
+@pytest.mark.parametrize(
+    "description, metadata, combined_metadata",
+    [
+        (None, None, None),
+        ("my_desc", None, {"description": "my_desc"}),
+        (None, {"key": [1]}, {"key": [1]}),
+        (
+            None,
+            {"key": [1], "description": "my_desc"},
+            {"description": "my_desc", "key": [1]},
+        ),
+        ("my_desc", {"key": [1]}, {"description": "my_desc", "key": [1]}),
+    ],
+)
+def test_create_namespace(namespace, description, metadata, combined_metadata):
+    create_namespace(namespace, description, metadata)
+    assert namespace in list_local_namespaces()
+    assert get_namespace_metadata(namespace) == combined_metadata
+    delete_namespace(namespace)
+
+
+@pytest.mark.parametrize("namespace", ["test_namespace"])
+def test_namespace_description_conflict(namespace):
+    # Re-creating the namespace does not raise a conflict unless the metadata conflicts
+    create_namespace(namespace)
+    create_namespace(namespace, description="my description", metadata={"key": [1]})
+    create_namespace(namespace, description="my description", metadata={"key": [1]})
+
+    with pytest.raises(
+        ValueError, match="Metadata for namespace 'test_namespace' already exists"
+    ):
+        create_namespace(namespace, description="a conflicting definition")
+
+    create_namespace(namespace, description="a new definition", overwrite=True)
+    assert get_namespace_metadata(namespace) == {"description": "a new definition"}
+
+    update_namespace(namespace, description="a third definition")
+    assert get_namespace_metadata(namespace) == {"description": "a third definition"}
+
+
+@pytest.mark.parametrize("namespace", ["test_namespace"])
+def test_create_nested_namespaces(namespace):
+    create_namespace(namespace, description="my description")
+    assert list_local_namespaces() == [namespace]
+    assert get_namespace_metadata(namespace) == {"description": "my description"}
+
+    nested_namespace = f"{namespace}/nested"
+    create_namespace(nested_namespace, description="is nested")
+    assert list_local_namespaces() == [namespace, nested_namespace]
+    assert get_namespace_metadata(nested_namespace) == {"description": "is nested"}
+
+
+def test_nonexistent_namespaces():
+    with pytest.raises(ValueError, match="does not exist"):
+        delete_namespace("does_not/exist")
+
+    with pytest.raises(ValueError, match="does not exist"):
+        update_namespace("does_not/exist")
+
+    with pytest.raises(ValueError, match="does not exist"):
+        get_namespace_metadata("does_not/exist")
+
+
+@pytest.mark.parametrize("namespace", ["/", "./", "../", "/namespace", "namespace/"])
+def test_create_invalid_namespace(namespace):
+    with pytest.raises(ValueError, match="Malformed namespace"):
+        create_namespace(namespace)
+
+
+@pytest.mark.parametrize("namespace", ["nested/namespace"])
+def test_create_namespaced_datasets(namespace):
+    env = gym.make("CartPole-v1")
+    env = DataCollector(env)
+
+    dataset_id_1 = f"{namespace}/cartpole-test-v1"
+    create_dummy_dataset_with_collecter_env_helper(dataset_id_1, env)
+    assert list_local_namespaces() == [namespace]
+    assert get_namespace_metadata(namespace) is None
+
+    update_namespace(namespace, description="new description")
+    assert get_namespace_metadata(namespace) == {"description": "new description"}
+
+    # Creating a new dataset in the same namespace doesn't change the namespace metadata
+    dataset_id_2 = f"{namespace}/cartpole-test-v2"
+    create_dummy_dataset_with_collecter_env_helper(dataset_id_2, env)
+    assert list_local_namespaces() == [namespace]
+    assert get_namespace_metadata(namespace) == {"description": "new description"}
+
+    assert list(list_local_datasets().keys()) == [dataset_id_1, dataset_id_2]
+
+    # Check that can only delete when empty
+    with pytest.raises(ValueError, match="is not empty"):
+        delete_namespace(namespace)
+
+    check_load_and_delete_dataset(dataset_id_1)
+    check_load_and_delete_dataset(dataset_id_2)
+    delete_namespace(namespace)

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -26,19 +26,14 @@ from tests.common import (
 @pytest.mark.parametrize(
     "description, metadata, combined_metadata",
     [
-        (None, None, None),
-        ("my_desc", None, {"description": "my_desc"}),
-        (None, {"key": [1]}, {"key": [1]}),
-        (
-            None,
-            {"key": [1], "description": "my_desc"},
-            {"description": "my_desc", "key": [1]},
-        ),
+        (None, {}, None),
+        ("my_desc", {}, {"description": "my_desc"}),
+        (None, {"key": [1]}, {"description": None, "key": [1]}),
         ("my_desc", {"key": [1]}, {"description": "my_desc", "key": [1]}),
     ],
 )
 def test_create_namespace(namespace, description, metadata, combined_metadata):
-    create_namespace(namespace, description, metadata)
+    create_namespace(namespace, description, **metadata)
     assert namespace in list_local_namespaces()
     assert get_namespace_metadata(namespace) == combined_metadata
     delete_namespace(namespace)

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -8,7 +8,7 @@ from minari.namespace import (
     delete_namespace,
     get_namespace_metadata,
     list_local_namespaces,
-    update_namespace,
+    update_namespace_metadata,
 )
 from tests.common import (
     check_load_and_delete_dataset,
@@ -45,22 +45,14 @@ def test_create_namespace(namespace, description, metadata, combined_metadata):
 
 
 @pytest.mark.parametrize("namespace", ["test_namespace"])
-def test_namespace_description_conflict(namespace):
-    # Re-creating the namespace does not raise a conflict unless the metadata conflicts
+def test_namespace_update(namespace):
     create_namespace(namespace)
-    create_namespace(namespace, description="my description", metadata={"key": [1]})
-    create_namespace(namespace, description="my description", metadata={"key": [1]})
 
-    with pytest.raises(
-        ValueError, match="Metadata for namespace 'test_namespace' already exists"
-    ):
-        create_namespace(namespace, description="a conflicting definition")
+    with pytest.raises(ValueError, match="Namespace 'test_namespace' already exists"):
+        create_namespace(namespace)
 
-    create_namespace(namespace, description="a new definition", overwrite=True)
+    update_namespace_metadata(namespace, description="a new definition")
     assert get_namespace_metadata(namespace) == {"description": "a new definition"}
-
-    update_namespace(namespace, description="a third definition")
-    assert get_namespace_metadata(namespace) == {"description": "a third definition"}
 
 
 @pytest.mark.parametrize("namespace", ["test_namespace"])
@@ -77,10 +69,7 @@ def test_create_nested_namespaces(namespace):
 
 def test_nonexistent_namespaces():
     with pytest.raises(ValueError, match="does not exist"):
-        delete_namespace("does_not/exist")
-
-    with pytest.raises(ValueError, match="does not exist"):
-        update_namespace("does_not/exist")
+        update_namespace_metadata("does_not/exist")
 
     with pytest.raises(ValueError, match="does not exist"):
         get_namespace_metadata("does_not/exist")
@@ -102,7 +91,7 @@ def test_create_namespaced_datasets(namespace):
     assert list_local_namespaces() == [namespace]
     assert get_namespace_metadata(namespace) is None
 
-    update_namespace(namespace, description="new description")
+    update_namespace_metadata(namespace, description="new description")
     assert get_namespace_metadata(namespace) == {"description": "new description"}
 
     # Creating a new dataset in the same namespace doesn't change the namespace metadata

--- a/tests/test_namespace_remote.py
+++ b/tests/test_namespace_remote.py
@@ -1,0 +1,96 @@
+import pytest
+from pytest import MonkeyPatch
+
+import minari
+from minari import MinariDataset
+from minari.namespace import (
+    create_namespace,
+    delete_namespace,
+    download_namespace_metadata,
+    get_namespace_metadata,
+    list_local_namespaces,
+    list_remote_namespaces,
+)
+from minari.storage.datasets_root_dir import get_dataset_path
+from tests.common import check_data_integrity, get_latest_compatible_dataset_id
+
+
+MINARI_TEST_REMOTE = "gcp://minari-datasets-test"
+
+
+@pytest.fixture()
+def use_test_server():
+    with MonkeyPatch.context() as mp:
+        mp.setenv("MINARI_REMOTE", MINARI_TEST_REMOTE)
+        yield
+
+
+def test_download_namespace_dataset(use_test_server):
+    dataset_id = get_latest_compatible_dataset_id("test_namespace", "door", "human")
+    remote_datasets = minari.list_remote_datasets()
+    assert dataset_id in remote_datasets
+
+    minari.download_dataset(dataset_id, force_download=True)
+    local_datasets = minari.list_local_datasets()
+    assert dataset_id in local_datasets
+
+    file_path = get_dataset_path(dataset_id)
+
+    with pytest.warns(
+        UserWarning,
+        match=f"Skipping Download. Dataset {dataset_id} found locally at {file_path}, Use force_download=True to download the dataset again.\n",
+    ):
+        assert minari.download_dataset(dataset_id) is None
+
+    dataset = minari.load_dataset(dataset_id)
+    assert isinstance(dataset, MinariDataset)
+
+    check_data_integrity(dataset.storage, dataset.episode_indices)
+
+    minari.delete_dataset(dataset_id)
+    local_datasets = minari.list_local_datasets()
+    assert dataset_id not in local_datasets
+
+
+def test_pull_namespace_metadata(use_test_server):
+    test_namespaces = {
+        "test_namespace",
+        "test_namespace/nested",
+        "test_namespace/nested_2",
+    }
+    example_metadata = {"key": [1, 2, 3], "1": {"2": 3}, "description": "a description"}
+
+    assert len(list_local_namespaces()) == 0
+    assert test_namespaces.issubset(list_remote_namespaces())
+
+    download_namespace_metadata("test_namespace/nested")
+    assert list_local_namespaces() == ["test_namespace/nested"]
+    assert get_namespace_metadata("test_namespace/nested") == example_metadata
+
+    download_namespace_metadata("test_namespace/nested_2")
+    assert list_local_namespaces() == [
+        "test_namespace/nested",
+        "test_namespace/nested_2",
+    ]
+    assert get_namespace_metadata("test_namespace/nested_2") is None
+
+    # Pulling again is a no-op, unless there is a metadata conflict
+    download_namespace_metadata("test_namespace/nested_2")
+    assert get_namespace_metadata("test_namespace/nested") == example_metadata
+    assert get_namespace_metadata("test_namespace/nested_2") is None
+
+    delete_namespace("test_namespace/nested_2")
+    create_namespace("test_namespace/nested_2", description="Conflicting description")
+
+    with pytest.warns(UserWarning, match="Skipping update for namespace"):
+        download_namespace_metadata("test_namespace/nested_2")
+
+    assert get_namespace_metadata("test_namespace/nested_2") == {
+        "description": "Conflicting description"
+    }
+
+    download_namespace_metadata("test_namespace/nested_2", overwrite=True)
+    assert get_namespace_metadata("test_namespace/nested_2") is None
+
+    with pytest.raises(ValueError, match="doesn't exist in the remote Farama server."):
+        download_namespace_metadata("test_namespace/nested_3")

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -10,11 +10,15 @@ from minari import DataCollector, MinariDataset, StepData
 from minari.data_collector import EpisodeBuffer
 from minari.dataset._storages import registry as storage_registry
 from tests.common import (
+    cartpole_test_dataset,
     check_data_integrity,
     check_env_recovery,
     check_env_recovery_with_subset_spaces,
     check_episode_data_integrity,
     check_load_and_delete_dataset,
+    dummy_box_dataset,
+    dummy_test_datasets,
+    dummy_text_dataset,
     get_sample_buffer_for_dataset_from_env,
 )
 
@@ -24,15 +28,7 @@ CODELINK = "https://github.com/Farama-Foundation/Minari/blob/main/tests/utils/te
 
 @pytest.mark.parametrize(
     "dataset_id,env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-box-test-v0", "DummyBoxEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-text-test-v0", "DummyTextEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
+    cartpole_test_dataset + dummy_test_datasets + dummy_text_dataset,
 )
 def test_generate_dataset_with_collector_env(dataset_id, env_id, register_dummy_envs):
     """Test DataCollector wrapper and Minari dataset creation."""
@@ -157,18 +153,13 @@ def test_record_infos_collector_env(info_override, register_dummy_envs):
     check_load_and_delete_dataset(dataset_id)
 
 
+@pytest.mark.parametrize("data_format", storage_registry.keys())
 @pytest.mark.parametrize(
     "dataset_id,env_id",
-    [
-        ("cartpole-test-v0", "CartPole-v1"),
-        ("dummy-dict-test-v0", "DummyDictEnv-v0"),
-        ("dummy-tuple-test-v0", "DummyTupleEnv-v0"),
-        ("dummy-text-test-v0", "DummyTextEnv-v0"),
-        ("dummy-combo-test-v0", "DummyComboEnv-v0"),
-        ("dummy-tuple-discrete-box-test-v0", "DummyTupleDiscreteBoxEnv-v0"),
-    ],
+    cartpole_test_dataset
+    + [x for x in dummy_test_datasets if x not in dummy_box_dataset]
+    + dummy_text_dataset,
 )
-@pytest.mark.parametrize("data_format", storage_registry.keys())
 def test_generate_dataset_with_external_buffer(
     dataset_id, env_id, data_format, register_dummy_envs
 ):

--- a/tests/utils/test_get_normalized_score.py
+++ b/tests/utils/test_get_normalized_score.py
@@ -1,19 +1,13 @@
 import gymnasium as gym
 import numpy as np
 
-import minari
 from minari import get_normalized_score
 from minari.data_collector.data_collector import DataCollector
 from tests.common import create_dummy_dataset_with_collecter_env_helper
 
 
 def test_ref_score():
-    local_datasets = minari.list_local_datasets()
-    if "cartpole-test-v0" in local_datasets:
-        minari.delete_dataset("cartpole-test-v0")
-
     env = gym.make("CartPole-v1")
-
     env = DataCollector(env)
     num_episodes = 10
 


### PR DESCRIPTION
# Description

This PR adds "namespaces", a directory-like hierarchical structure that can be used to group datasets together. For example, creating a dataset with id `my_namespace/cartpole-test-v0` will create a namespace `my_namespace`, containing the CartPole dataset as well with all other datasets starting with "my_namespace/". Namespaces can be arbitrarily nested, and can be assigned metadata which can be used describe the datasets it contains (or any other auxiliary data). These features should help organise the Minari database as it grows, and particularly as third-party datasets are added.

Dataset ids without a "/" are considered to be in the "top-level" namespace, thus this is a non-breaking change.

Internally, namespaces affect three things:
- The first part of the `dataset_id`, e.g. `my_namespace` in `my_namespace/cartpole-test-v0`.
- The directory in which the dataset is stored. E.g. `my_namespace/cartpole-test-v0` would be stored in the subdirectory `my_namespace` in the Minari datasets directory.
- Namespace metadata files `namespace_metadata.json`, which distinguish a namespace from an ordinary folder, and can hold optional metadata.

Functionality is provided to create, delete and update local namespaces in `minari.namespaces`. Namespaces can also be uploaded to the remote Farama server. Since this introduces a high potential for data conflicts, the interface is rather restrictive. Once non-empty namespace metadata is uploaded to the remote it cannot be overwritten and would need to be modified manually on the server. Namespace data is not synced between the local and remote database, except when uploading a dataset with a namespace that does not exist in the remote. Metadata can be synced manually using `upload_namespace()` and `download_namespace_data()`.

To provide some test coverage of the remote functionality, I have created a test GCP bucket [minari-datasets-test](https://console.cloud.google.com/storage/browser/minari-datasets-test) which holds some dummy namespaced datasets. I would be happy to move this over to an official Farama server, or alternatively remove the tests in `test_namespace_remote.py` until there are some namespaced datasets in the main GCP bucket.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
