### PR TITLE
ENH: add requirements in metadata

### DIFF
--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -8,7 +8,7 @@ from typing import Dict, OrderedDict
 from generate_gif import generate_gif
 from gymnasium.envs.registration import EnvSpec
 
-from minari import list_remote_datasets
+import minari
 from minari.dataset.minari_dataset import gen_dataset_id, parse_dataset_id
 from minari.namespace import download_namespace_metadata, get_namespace_metadata
 from minari.utils import get_dataset_spec_dict, get_env_spec_dict
@@ -26,7 +26,7 @@ def _md_table(table_dict: Dict[str, str]) -> str:
 
 
 def main():
-    remote_datasets = list_remote_datasets(latest_version=True)
+    remote_datasets = minari.list_remote_datasets(latest_version=True)
     for i, (dataset_id, metadata) in enumerate(remote_datasets.items()):
         namespace, dataset_name, version = parse_dataset_id(dataset_id)
         if namespace is not None:
@@ -68,7 +68,9 @@ def _generate_dataset_page(dataset_id, metadata):
 
     description = metadata.get("description")
     try:
-        generate_gif(dataset_id)
+        minari.download_dataset(dataset_id)
+        generate_gif(dataset_id, path=DATASET_FOLDER)
+        minari.delete_dataset(dataset_id)
         img_link_str = f'<img src="../{versioned_name}.gif" width="200" style="display: block; margin:0 auto"/>'
     except Exception as e:
         logging.warning(f"Failed to generate gif for {dataset_id}: {e}")

--- a/docs/_scripts/generate_gif.py
+++ b/docs/_scripts/generate_gif.py
@@ -36,7 +36,7 @@ def generate_gif(dataset_id, num_frames=256, fps=16):
             act = _space_at(episode.actions, step_id)
             env.step(act)
             images.append(env.render())
-        
+
         episode_id += 1
 
     env.close()

--- a/docs/_scripts/generate_gif.py
+++ b/docs/_scripts/generate_gif.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 
 import imageio
 
@@ -16,6 +18,10 @@ def _space_at(values, index):
 
 def generate_gif(dataset_id, num_frames=256, fps=16):
     dataset = minari.load_dataset(dataset_id, download=True)
+    requirements = dataset.storage.metadata.get("requirements", [])
+    for req in requirements:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", f'"{req}"'])
+
     env = dataset.recover_environment(render_mode="rgb_array")
     images = []
     ep_id = 0
@@ -33,6 +39,9 @@ def generate_gif(dataset_id, num_frames=256, fps=16):
             images.append(env.render())
 
         ep_id += 1
+
+    env.close()
+    minari.delete_dataset(dataset_id)
 
     dataset_path = os.path.join(os.path.dirname(__file__), "..", "datasets")
     gif_path = os.path.join(dataset_path, f"{dataset_id}.gif")

--- a/docs/_scripts/generate_gif.py
+++ b/docs/_scripts/generate_gif.py
@@ -24,21 +24,20 @@ def generate_gif(dataset_id, num_frames=256, fps=16):
 
     env = dataset.recover_environment(render_mode="rgb_array")
     images = []
-    ep_id = 0
+    if dataset[0].seed is None:
+        raise ValueError("Cannot reproduce episodes with unknown seed.")
 
+    episode_id = 0
     while len(images) < num_frames:
-        episode = dataset[ep_id]
-        if episode.seed is None:
-            raise ValueError("Cannot reproduce episodes with unknown seed.")
-
+        episode = dataset[episode_id]
         env.reset(seed=episode.seed)
         images.append(env.render())
         for step_id in range(episode.total_steps):
             act = _space_at(episode.actions, step_id)
             env.step(act)
             images.append(env.render())
-
-        ep_id += 1
+        
+        episode_id += 1
 
     env.close()
     minari.delete_dataset(dataset_id)

--- a/docs/_scripts/generate_gif.py
+++ b/docs/_scripts/generate_gif.py
@@ -16,8 +16,8 @@ def _space_at(values, index):
         return values[index]
 
 
-def generate_gif(dataset_id, num_frames=256, fps=16):
-    dataset = minari.load_dataset(dataset_id, download=True)
+def generate_gif(dataset_id, path, num_frames=256, fps=16):
+    dataset = minari.load_dataset(dataset_id)
     requirements = dataset.storage.metadata.get("requirements", [])
     for req in requirements:
         subprocess.check_call([sys.executable, "-m", "pip", "install", f'"{req}"'])
@@ -40,9 +40,7 @@ def generate_gif(dataset_id, num_frames=256, fps=16):
         episode_id += 1
 
     env.close()
-    minari.delete_dataset(dataset_id)
 
-    dataset_path = os.path.join(os.path.dirname(__file__), "..", "datasets")
-    gif_path = os.path.join(dataset_path, f"{dataset_id}.gif")
-    imageio.mimsave(gif_path, images, fps=fps)
-    return gif_path
+    gif_file = os.path.join(path, f"{dataset_id}.gif")
+    imageio.mimsave(gif_file, images, fps=fps)
+    return gif_file

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -45,6 +45,7 @@ When creating a Minari dataset the default global metadata will be the following
 | `author_email`          | `set of str`      | Email of the authors that created the dataset.|
 | `algorithm_name`        | `str`      | Name of the expert policy used to create the dataset. |
 | `minari_version`        | `str`      | Version of Minari that generated the dataset. |
+| `requirements`          | `list of str`      | List of requirements in pip-style to load the environment. |
 
 
 where only `dataset_id`, `total_episodes`, and `total_steps` are mandatory (with the latter two computed automatically).

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -238,6 +238,7 @@ class DataCollector(gym.Wrapper):
         expert_policy: Optional[Callable[[ObsType], ActType]] = None,
         num_episodes_average_score: int = 100,
         description: Optional[str] = None,
+        requirements: Optional[list] = None,
     ):
         """Create a Minari dataset using the data collected from stepping with a Gymnasium environment wrapped with a `DataCollector` Minari wrapper.
 
@@ -259,6 +260,7 @@ class DataCollector(gym.Wrapper):
                                                                             `ref_max_score` and `expert_policy` can't be passed at the same time. Default to None
             num_episodes_average_score (int): number of episodes to average over the returns to compute `ref_min_score` and `ref_max_score`. Default to 100.
             description (str, optional): description of the dataset being created. Defaults to None.
+            requirements (list of str, optional): list of requirements to load the environment and reproduce the dataset. Defaults to None.
 
         Returns:
             MinariDataset
@@ -282,6 +284,7 @@ class DataCollector(gym.Wrapper):
             expert_policy,
             num_episodes_average_score,
             description,
+            requirements,
         )
 
         self._save_to_disk(dataset_path, metadata)

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -260,7 +260,7 @@ class DataCollector(gym.Wrapper):
                                                                             `ref_max_score` and `expert_policy` can't be passed at the same time. Default to None
             num_episodes_average_score (int): number of episodes to average over the returns to compute `ref_min_score` and `ref_max_score`. Default to 100.
             description (str, optional): description of the dataset being created. Defaults to None.
-            requirements (list of str, optional): list of requirements to load the environment and reproduce the dataset. Defaults to None.
+            requirements (list of str, optional): list of requirements in pip-style to load the environment and reproduce the dataset. For example, `mujoco>=3.1.0,<3.2.0`, which indicate the supported version range for mujoco package. Defaults to None.
 
         Returns:
             MinariDataset

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -166,7 +166,6 @@ class MinariDataset:
 
         Args:
             eval_env (bool): if True, the returned Gymnasium environment will be that intended to be used for evaluation. If no eval_env was specified when creating the dataset, the returned environment will be the same as the one used for creating the dataset. Default False.
-            install_requirements (bool): if True, eventual requirements will be installed before creating the environment. Default False.
             **kwargs: any other parameter that you want to pass to the `gym.make` function.
 
         Returns:

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import os
 import re
 from dataclasses import dataclass, field
@@ -9,6 +10,8 @@ import gymnasium as gym
 import numpy as np
 from gymnasium import error, logger
 from gymnasium.envs.registration import EnvSpec
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import Version
 
 from minari.data_collector.episode_buffer import EpisodeBuffer
 from minari.dataset.episode_data import EpisodeData
@@ -162,12 +165,34 @@ class MinariDataset:
         """Recover the Gymnasium environment used to create the dataset.
 
         Args:
-            eval_env (bool): if True the returned Gymnasium environment will be that intended to be used for evaluation. If no eval_env was specified when creating the dataset, the returned environment will be the same as the one used for creating the dataset. Default False.
+            eval_env (bool): if True, the returned Gymnasium environment will be that intended to be used for evaluation. If no eval_env was specified when creating the dataset, the returned environment will be the same as the one used for creating the dataset. Default False.
+            install_requirements (bool): if True, eventual requirements will be installed before creating the environment. Default False.
             **kwargs: any other parameter that you want to pass to the `gym.make` function.
 
         Returns:
             environment: Gymnasium environment
         """
+        requirements = self._data.metadata.get("requirements", [])
+        for req_str in requirements:
+            try:
+                req = Requirement(req_str)
+            except InvalidRequirement:
+                logger.warn(f"Ignoring malformed requirement `{req_str}`")
+                continue
+
+            try:
+                installed_version = Version(importlib.metadata.version(req.name))
+            except importlib.metadata.PackageNotFoundError:
+                logger.warn(
+                    f'Package {req.name} is not installed. Install it with `pip install "{req_str}"`'
+                )
+            else:
+                if not req.specifier.contains(installed_version):
+                    logger.warn(
+                        f"Installed {req.name} version {installed_version} does not meet the requirement {req.specifier}.\n"
+                        f'We recommend to install the required version with `pip install "{req_str}"`'
+                    )
+
         if eval_env:
             if self._eval_env_spec is not None:
                 return gym.make(self._eval_env_spec, **kwargs)

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -224,6 +224,7 @@ def _generate_dataset_metadata(
     expert_policy: Optional[Callable[[ObsType], ActType]],
     num_episodes_average_score: int,
     description: Optional[str],
+    requirements: Optional[list],
 ) -> Dict[str, Any]:
     """Return the metadata dictionary of the dataset."""
     dataset_metadata: Dict[str, Any] = {
@@ -323,6 +324,8 @@ def _generate_dataset_metadata(
         dataset_metadata["ref_min_score"] = ref_min_score
         dataset_metadata["num_episodes_average_score"] = num_episodes_average_score
 
+    if requirements is not None:
+        dataset_metadata["requirements"] = requirements
     return dataset_metadata
 
 
@@ -343,6 +346,7 @@ def create_dataset_from_buffers(
     num_episodes_average_score: int = 100,
     description: Optional[str] = None,
     data_format: Optional[str] = None,
+    requirements: Optional[list] = None,
 ):
     """Create Minari dataset from a list of episode dictionary buffers.
 
@@ -371,6 +375,7 @@ def create_dataset_from_buffers(
         observation_space (gym.spaces.Space, optional): observation space of the environment. If None (default) use the environment observation space.
         description (str, optional): description of the dataset being created. Defaults to None.
         data_format (str, optional): Data format to store the data in the Minari dataset. If None (defaults), it will use the default format of MinariStorage.
+        requirements (list of str, optional): list of requirements to load the environment and reproduce the dataset. Defaults to None.
 
     Returns:
         MinariDataset
@@ -414,6 +419,7 @@ def create_dataset_from_buffers(
         expert_policy,
         num_episodes_average_score,
         description,
+        requirements,
     )
 
     data_format_kwarg = {"data_format": data_format} if data_format is not None else {}

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -375,7 +375,7 @@ def create_dataset_from_buffers(
         observation_space (gym.spaces.Space, optional): observation space of the environment. If None (default) use the environment observation space.
         description (str, optional): description of the dataset being created. Defaults to None.
         data_format (str, optional): Data format to store the data in the Minari dataset. If None (defaults), it will use the default format of MinariStorage.
-        requirements (list of str, optional): list of requirements to load the environment and reproduce the dataset. Defaults to None.
+        requirements (list of str, optional): list of requirements in pip-style to load the environment and reproduce the dataset. For example, `mujoco>=3.1.0,<3.2.0`, which indicate the supported version range for mujoco package. Defaults to None.
 
     Returns:
         MinariDataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "typing_extensions>=4.4.0",
     "typer[all]>=0.9.0",
     "gymnasium>=0.28.1",
+    "packaging",
 ]
 
 dynamic = ["version"]

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -466,7 +466,7 @@ def test_parse_gen_dataset_id_inverse_backward(namespace, dataset_name, version)
     assert attrs == parse_dataset_id(gen_dataset_id(*attrs))
 
 
-def test_missing_requirements():
+def test_requirements():
     dataset_id = "dummy-test-v0"
     env = DataCollector(gym.make("CartPole-v1"))
     dataset = create_dummy_dataset_with_collecter_env_helper(

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -1,8 +1,8 @@
 import json
 import os
 import re
-from typing import Any
 import warnings
+from typing import Any
 
 import gymnasium as gym
 import numpy as np
@@ -489,7 +489,9 @@ def test_requirements():
     ):
         dataset.recover_environment()
 
-    dataset.storage.update_metadata({"requirements": [f"minari>=0.0.1,<={minari.__version__}"]})
+    dataset.storage.update_metadata(
+        {"requirements": [f"minari>=0.0.1,<={minari.__version__}"]}
+    )
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         dataset.recover_environment()

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -464,3 +464,29 @@ def test_parse_gen_dataset_id_inverse_backward(namespace, dataset_name, version)
     """Check parse_dataset_id() and gen_dataset_id() are inverses. Backward direction."""
     attrs = (namespace, dataset_name, version)
     assert attrs == parse_dataset_id(gen_dataset_id(*attrs))
+
+
+def test_missing_requirements():
+    dataset_id = "dummy-test-v0"
+    env = DataCollector(gym.make("CartPole-v1"))
+    dataset = create_dummy_dataset_with_collecter_env_helper(
+        dataset_id, env, requirements=["mal<formed@@3.2"]
+    )
+
+    with pytest.warns(UserWarning, match="Ignoring malformed requirement"):
+        dataset.recover_environment()
+
+    dataset.storage.update_metadata({"requirements": ["non-existent-package"]})
+    with pytest.warns(
+        UserWarning, match="is not installed. Install it with `pip install"
+    ):
+        dataset.recover_environment()
+
+    dataset.storage.update_metadata({"requirements": [f"minari<{minari.__version__}"]})
+    with pytest.warns(
+        UserWarning, match="We recommend to install the required version"
+    ):
+        dataset.recover_environment()
+
+    dataset.storage.update_metadata({"requirements": [f"minari=={minari.__version__}"]})
+    dataset.recover_environment()

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from typing import Any
+import warnings
 
 import gymnasium as gym
 import numpy as np
@@ -488,5 +489,7 @@ def test_requirements():
     ):
         dataset.recover_environment()
 
-    dataset.storage.update_metadata({"requirements": [f"minari=={minari.__version__}"]})
-    dataset.recover_environment()
+    dataset.storage.update_metadata({"requirements": [f"minari>=0.0.1,<={minari.__version__}"]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dataset.recover_environment()


### PR DESCRIPTION
Add requirements in metadata that can be used to indicate which packages and versions are needed for the environment to work as expected. 
