### PR TITLE
ENH: Move seed to episode metadata

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,4 +1,4 @@
-name: Test Documentation
+name: test documentation
 on:
   pull_request:
   push:
@@ -7,7 +7,7 @@ permissions:
   contents: read
 jobs:
   docs:
-    name: Test documentation
+    name: test documentation
     runs-on: ubuntu-latest
     env:
       SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -1,4 +1,4 @@
-name: test-integrations
+name: test integrations
 
 on:
   pull_request:

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -1,4 +1,4 @@
-name: build
+name: test-integrations
 
 on:
   pull_request:
@@ -11,14 +11,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - run: |
           docker build -f bin/Dockerfile \
-            --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+            --build-arg PYTHON_VERSION=3.11 \
             --tag minari-docker .
       - name: Run tests
-        run: docker run minari-docker pytest tests/* -k "not test_docs.py and not integrations"
+        run: docker run minari-docker pytest tests/integrations

--- a/docs/_scripts/generate_gif.py
+++ b/docs/_scripts/generate_gif.py
@@ -26,15 +26,18 @@ def generate_gif(dataset_id, path, num_frames=256, fps=16):
     dataset = minari.load_dataset(dataset_id)
     env = dataset.recover_environment(render_mode="rgb_array")
     images = []
-    if dataset[0].seed is None:
+    if "seed" not in dataset.storage.get_episode_metadata([0])[0]:
         raise ValueError("Cannot reproduce episodes with unknown seed.")
 
     episode_id = 0
     while len(images) < num_frames:
         episode = dataset[episode_id]
-        env.reset(seed=episode.seed)
+        episode_metadata = dataset.storage.get_episode_metadata([episode_id])[0]
+        env.reset(
+            seed=episode_metadata.get("seed"), options=episode_metadata.get("options")
+        )
         images.append(env.render())
-        for step_id in range(episode.total_steps):
+        for step_id in range(len(episode)):
             act = _space_at(episode.actions, step_id)
             env.step(act)
             images.append(env.render())

--- a/docs/api/minari_dataset/minari_storage.md
+++ b/docs/api/minari_dataset/minari_storage.md
@@ -15,6 +15,7 @@
 .. autofunction:: minari.dataset.minari_storage.MinariStorage.update_episodes
 .. autofunction:: minari.dataset.minari_storage.MinariStorage.update_metadata
 .. autofunction:: minari.dataset.minari_storage.MinariStorage.update_episode_metadata
+.. autofunction:: minari.dataset.minari_storage.MinariStorage.get_episode_metadata
 .. autofunction:: minari.dataset.minari_storage.MinariStorage.apply
 .. autofunction:: minari.dataset.minari_storage.MinariStorage.update_from_storage
 .. autofunction:: minari.dataset.minari_storage.MinariStorage.get_size

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -95,8 +95,6 @@ The `sampled_episodes` variable will be a list of 10 `EpisodeData` elements, eac
 | Field             | Type                                 | Description                                                   |
 | ----------------- | ------------------------------------ | ------------------------------------------------------------- |
 | `id`              | `int`                           | ID of the episode.                                            |
-| `seed`            | `int`                           | Seed used to reset the episode.                               |
-| `total_steps`     | `int`                           | Number of steps in the episode.                               |
 | `observations`    | `np.ndarray`, `list`, `tuple`, `dict` | Stacked observations for each step including initial observation.    |
 | `actions`         | `np.ndarray`, `list`, `tuple`, `dict` | Stacked actions for each step.                                       |
 | `rewards`         | `np.ndarray`                         | Rewards for each step.                                        |
@@ -107,3 +105,5 @@ The `sampled_episodes` variable will be a list of 10 `EpisodeData` elements, eac
 As mentioned in the `Supported Spaces` section, many different observation and action spaces are supported so the data type for these fields are dependent on the environment being used.
 
 Moreover, when creating a dataset with `DataCollector`, if the `DataCollector` is initialized with `record_infos=True`, an info dict must be provided from every call to the environment's `step` and `reset` function. The structure of the info dictionary must be the same across steps. Given that it is not guaranteed that all Gymnasium environments provide infos at every step, we provide the `StepDataCallback` which can modify the infos from a non-compliant environment so they have the same structure at every step.
+
+Other optional attributes of the episode, such as reset `seed` and `options`, can be found in the episode metadata using `MinariStorage.get_episode_metadata`.

--- a/docs/tutorials/using_datasets/IQL_torchrl.py
+++ b/docs/tutorials/using_datasets/IQL_torchrl.py
@@ -164,13 +164,13 @@ env.set_seed(seed)
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 
 # %%
-# The Minari dataset we will be using is `D4RL/pen/human-v1 <https://minari.farama.org/main/datasets/pen/human/>`_, which consists of 25 human demonstrations. We can create a replay buffer using ``MinariExperienceReplay()``:
+# The Minari dataset we will be using is `D4RL/pen/human-v2 <https://minari.farama.org/main/datasets/pen/human/>`_, which consists of 25 human demonstrations. We can create a replay buffer using ``MinariExperienceReplay()``:
 
 # %%
 from torchrl.data.datasets.minari_data import MinariExperienceReplay
 from torchrl.data.replay_buffers import SamplerWithoutReplacement
 
-dataset_id = "D4RL/pen/human-v1"
+dataset_id = "D4RL/pen/human-v2"
 batch_size = 256
 
 replay_buffer = MinariExperienceReplay(

--- a/docs/tutorials/using_datasets/behavioral_cloning.py
+++ b/docs/tutorials/using_datasets/behavioral_cloning.py
@@ -107,8 +107,6 @@ class PolicyNetwork(nn.Module):
 def collate_fn(batch):
     return {
         "id": torch.Tensor([x.id for x in batch]),
-        "seed": torch.Tensor([x.seed for x in batch]),
-        "total_steps": torch.Tensor([x.total_steps for x in batch]),
         "observations": torch.nn.utils.rnn.pad_sequence(
             [torch.as_tensor(x.observations) for x in batch],
             batch_first=True

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -204,6 +204,7 @@ class DataCollector(gym.Wrapper):
         self._buffer = EpisodeBuffer(
             id=self._episode_id,
             seed=seed,
+            options=options,
             observations=step_data["observation"],
             infos=step_data["info"] if self._record_infos else None,
         )

--- a/minari/data_collector/episode_buffer.py
+++ b/minari/data_collector/episode_buffer.py
@@ -12,6 +12,7 @@ class EpisodeBuffer:
 
     id: Optional[int] = None
     seed: Optional[int] = None
+    options: Optional[dict] = None
     observations: Union[None, list, dict, tuple] = None
     actions: Union[None, list, dict, tuple] = None
     rewards: list = field(default_factory=list)
@@ -60,6 +61,7 @@ class EpisodeBuffer:
         return EpisodeBuffer(
             id=self.id,
             seed=self.seed,
+            options=self.options,
             observations=observations,
             actions=actions,
             rewards=self.rewards,

--- a/minari/dataset/_storages/hdf5_storage.py
+++ b/minari/dataset/_storages/hdf5_storage.py
@@ -79,6 +79,8 @@ class HDF5Storage(MinariStorage):
                     options_group = ep_group["options"]
                     assert isinstance(options_group, h5py.Group)
                     metadata["options"] = self._decode_dict(options_group)
+                if "seed" in metadata:
+                    metadata["seed"] = int(metadata["seed"])
                 out.append(metadata)
 
         return out

--- a/minari/dataset/_storages/hdf5_storage.py
+++ b/minari/dataset/_storages/hdf5_storage.py
@@ -80,7 +80,7 @@ class HDF5Storage(MinariStorage):
                     assert isinstance(options_group, h5py.Group)
                     metadata["options"] = self._decode_dict(options_group)
                 out.append(metadata)
-    
+
         return out
 
     def _decode_space(

--- a/minari/dataset/_storages/hdf5_storage.py
+++ b/minari/dataset/_storages/hdf5_storage.py
@@ -79,7 +79,7 @@ class HDF5Storage(MinariStorage):
                     options_group = ep_group["options"]
                     assert isinstance(options_group, h5py.Group)
                     metadata["options"] = self._decode_dict(options_group)
-                if "seed" in metadata:
+                if metadata.get("seed") is not None:
                     metadata["seed"] = int(metadata["seed"])
                 out.append(metadata)
 

--- a/minari/dataset/episode_data.py
+++ b/minari/dataset/episode_data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -9,8 +9,6 @@ class EpisodeData:
     """Contains the datasets data for a single episode."""
 
     id: int
-    seed: Optional[int]
-    total_steps: int
     observations: Any
     actions: Any
     rewards: np.ndarray
@@ -18,12 +16,14 @@ class EpisodeData:
     truncations: np.ndarray
     infos: dict
 
+    def __len__(self) -> int:
+        return len(self.rewards)
+
     def __repr__(self) -> str:
         return (
             "EpisodeData("
-            f"id={repr(self.id)}, "
-            f"seed={repr(self.seed)}, "
-            f"total_steps={self.total_steps}, "
+            f"id={self.id}, "
+            f"total_steps={len(self)}, "
             f"observations={EpisodeData._repr_space_values(self.observations)}, "
             f"actions={EpisodeData._repr_space_values(self.actions)}, "
             f"rewards=ndarray of {len(self.rewards)} floats, "

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -301,12 +301,10 @@ class MinariDataset:
             if self.episode_indices is None:
                 self._total_steps = self.storage.total_steps
             else:
-                self._total_steps = sum(
-                    self.storage.apply(
-                        lambda episode: episode["total_steps"],
-                        episode_indices=self.episode_indices,
-                    )
-                )
+                self._total_steps = 0
+                metadatas = self.storage.get_episode_metadata(self.episode_indices)
+                for m in metadatas:
+                    self._total_steps += m["total_steps"]
         return int(self._total_steps)
 
     @property

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -238,6 +238,18 @@ class MinariStorage(ABC):
         """
         ...
 
+    @abstractmethod
+    def get_episode_metadata(self, episode_indices: Iterable[int]) -> List[Dict]:
+        """Get the metadata of episodes.
+
+        Args:
+            episode_indices (Iterable[int]): episodes id to return
+
+        Returns:
+            metadatas (List[Dict]): list of episodes metadata
+        """
+        ...
+
     def apply(
         self,
         function: Callable[[dict], Any],

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,6 @@
 import sys
 import unicodedata
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import gymnasium as gym
 import numpy as np
@@ -11,7 +11,6 @@ import minari
 from minari import DataCollector, EpisodeData, MinariDataset, StepData
 from minari.data_collector import EpisodeBuffer
 from minari.dataset.minari_dataset import gen_dataset_id
-from minari.dataset.minari_storage import MinariStorage
 from minari.storage.hosting import get_remote_dataset_versions
 
 
@@ -497,47 +496,45 @@ def check_env_recovery(
         ), f"recovered_eval_env spec: {recovered_eval_env.spec}\noriginal spec: {evaluation_environment}"
 
 
-def check_data_integrity(data: MinariStorage, episode_indices: Iterable[int]):
-    """Checks to see if a MinariStorage episode has consistent data and has episodes at the expected indices.
+def check_data_integrity(dataset: MinariDataset, episode_indices: List[int]):
+    """Checks to see if MinariDataset episodes have consistent data and has episodes at the expected indices.
 
     Args:
-        data (MinariStorage): a MinariStorage instance
+        dataset (MinariDataset): a MinariDataset instance
         episode_indices (Iterable[int]): the list of episode indices expected
     """
-    episodes = list(data.get_episodes(episode_indices))
+    episodes = list(dataset.iterate_episodes(episode_indices))
     # verify we have the right number of episodes, available at the right indices
-    assert data.total_episodes == len(
+    assert dataset.total_episodes == len(
         episodes
-    ), f"{data.total_episodes} != {len(episodes)}"
+    ), f"{dataset.total_episodes} != {len(episodes)}"
     total_steps = 0
 
-    observation_space = data.metadata["observation_space"]
-    action_space = data.metadata["action_space"]
+    observation_space = dataset.observation_space
+    action_space = dataset.action_space
 
     # verify the actions and observations are in the appropriate action space and observation space, and that the episode lengths are correct
     for episode in episodes:
-        total_steps += episode["total_steps"]
+        total_steps += len(episode)
         _check_space_elem(
-            episode["observations"],
+            episode.observations,
             observation_space,
-            episode["total_steps"] + 1,
+            len(episode) + 1,
         )
-        _check_space_elem(episode["actions"], action_space, episode["total_steps"])
+        _check_space_elem(episode.actions, action_space, len(episode))
 
-        for i in range(episode["total_steps"] + 1):
-            obs = _reconstuct_obs_or_action_at_index_recursive(
-                episode["observations"], i
-            )
+        for i in range(len(episode) + 1):
+            obs = _reconstuct_obs_or_action_at_index_recursive(episode.observations, i)
             assert observation_space.contains(obs)
-        for i in range(episode["total_steps"]):
-            action = _reconstuct_obs_or_action_at_index_recursive(episode["actions"], i)
+        for i in range(len(episode)):
+            action = _reconstuct_obs_or_action_at_index_recursive(episode.actions, i)
             assert action_space.contains(action)
 
-        assert episode["total_steps"] == len(episode["rewards"])
-        assert episode["total_steps"] == len(episode["terminations"])
-        assert episode["total_steps"] == len(episode["truncations"])
+        assert len(episode) == len(episode.rewards)
+        assert len(episode) == len(episode.terminations)
+        assert len(episode) == len(episode.truncations)
 
-    assert total_steps == data.total_steps
+    assert total_steps == dataset.total_steps
 
 
 def get_info_at_step_index(infos: Dict, step_index: int) -> Dict:
@@ -662,11 +659,11 @@ def check_episode_data_integrity(
         _check_space_elem(
             episode.observations,
             observation_space,
-            episode.total_steps + 1,
+            len(episode) + 1,
         )
-        _check_space_elem(episode.actions, action_space, episode.total_steps)
+        _check_space_elem(episode.actions, action_space, len(episode))
 
-        for i in range(episode.total_steps + 1):
+        for i in range(len(episode) + 1):
             obs = _reconstuct_obs_or_action_at_index_recursive(episode.observations, i)
             if info_sample is not None:
                 assert episode.infos is not None
@@ -676,13 +673,13 @@ def check_episode_data_integrity(
 
             assert observation_space.contains(obs)
 
-        for i in range(episode.total_steps):
+        for i in range(len(episode)):
             action = _reconstuct_obs_or_action_at_index_recursive(episode.actions, i)
             assert action_space.contains(action)
 
-        assert episode.total_steps == len(episode.rewards)
-        assert episode.total_steps == len(episode.terminations)
-        assert episode.total_steps == len(episode.truncations)
+        assert len(episode) == len(episode.rewards)
+        assert len(episode) == len(episode.terminations)
+        assert len(episode) == len(episode.truncations)
 
 
 def check_infos_equal(info_1: Dict, info_2: Dict) -> bool:

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,12 +38,13 @@ class DummyBoxEnv(gym.Env):
         self.observation_space = spaces.Box(
             low=-1, high=4, shape=(3,), dtype=np.float32
         )
+        self._max_timesteps = 5
 
     def _get_info(self):
         return {"timestep": np.array([self.timestep])}
 
     def step(self, action):
-        terminated = self.timestep > 5
+        terminated = self.timestep > self._max_timesteps
         self.timestep += 1
 
         return (
@@ -56,6 +57,8 @@ class DummyBoxEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         self.timestep = 0
+        if options:
+            self._max_timesteps = options.get("max_timesteps", self._max_timesteps)
         self.observation_space.seed(seed)
         return self.observation_space.sample(), self._get_info()
 

--- a/tests/data_collector/callbacks/test_step_data_callback.py
+++ b/tests/data_collector/callbacks/test_step_data_callback.py
@@ -100,7 +100,7 @@ def test_data_collector_step_data_callback(data_format, register_dummy_envs):
     assert dataset.spec.total_episodes == num_episodes
     assert len(dataset.episode_indices) == num_episodes
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
 
     check_env_recovery_with_subset_spaces(
         env.env, dataset, action_space_subset, observation_space_subset
@@ -150,7 +150,7 @@ def test_data_collector_step_data_callback_info_correction(
     assert dataset.spec.total_episodes == num_episodes
     assert len(dataset.episode_indices) == num_episodes
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
 
     check_env_recovery(env.env, dataset)
 

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -81,8 +81,6 @@ def get_single_step_from_episode(episode: EpisodeData, index: int) -> EpisodeDat
 
     step_data = {
         "id": episode.id,
-        "total_steps": 1,
-        "seed": None,
         "observations": observation,
         "actions": action,
         "rewards": episode.rewards[index],
@@ -133,7 +131,7 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
     episodes_generator = dataset.iterate_episodes()
     last_step = get_single_step_from_episode(next(episodes_generator), -1)
     for episode in episodes_generator:
-        assert episode.total_steps == ForceTruncateStepDataCallback.episode_steps
+        assert len(episode) == ForceTruncateStepDataCallback.episode_steps
         first_step = get_single_step_from_episode(episode, 0)
         # Check that the last observation of the previous episode is carried over to the next episode
         # as the reset observation.
@@ -190,17 +188,19 @@ def test_reproducibility(seed, data_format, register_dummy_envs):
     env = dataset.recover_environment()
 
     for episode in dataset.iterate_episodes():
-        if seed is None:
-            assert isinstance(episode.seed, int)
-            assert episode.seed >= 0
-        else:
-            assert seed == episode.seed
+        episode_metadata = dataset.storage.get_episode_metadata([episode.id])[0]
+        episode_seed = episode_metadata["seed"]
+        assert episode_seed >= 0
+        if seed is not None:
+            assert seed == episode_seed
 
-        obs, _ = env.reset(seed=episode.seed)
+        obs, _ = env.reset(
+            seed=int(episode_seed), options=episode_metadata.get("options")
+        )
 
         assert np.allclose(obs, episode.observations[0])
 
-        for k in range(episode.total_steps):
+        for k in range(len(episode)):
             obs, rew, term, trunc, _ = env.step(episode.actions[k])
             assert np.allclose(obs, episode.observations[k + 1])
             assert rew == episode.rewards[k]

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -157,7 +157,8 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
 
 @pytest.mark.parametrize("data_format", get_storage_keys())
 @pytest.mark.parametrize("seed", [None, 0, 42, MAX_UINT64])
-def test_reproducibility(seed, data_format, register_dummy_envs):
+@pytest.mark.parametrize("options", [None, {"max_timesteps": 3}])
+def test_reproducibility(seed, data_format, options, register_dummy_envs):
     """Test episodes are reproducible, even if an explicit reset seed is not set."""
     dataset_id = "dummy-box/test-v0"
     env_id = "DummyBoxEnv-v0"
@@ -166,7 +167,7 @@ def test_reproducibility(seed, data_format, register_dummy_envs):
     env = DataCollector(gym.make(env_id), data_format=data_format)
 
     for _ in range(num_episodes):
-        env.reset(seed=seed)
+        env.reset(seed=seed, options=options)
 
         trunc = False
         term = False

--- a/tests/dataset/test_dataset_download.py
+++ b/tests/dataset/test_dataset_download.py
@@ -88,11 +88,11 @@ def test_download_error_messages(monkeypatch):
         with pytest.raises(
             ValueError, match="Couldn't find any compatible version of dataset"
         ):
-            minari.download_dataset("D4RL/door/human-v1")
+            minari.download_dataset("D4RL/door/human-v2")
 
         with pytest.warns(match="Couldn't find any compatible version of dataset"):
-            minari.download_dataset("D4RL/door/human-v1", force_download=True)
-        minari.delete_dataset("D4RL/door/human-v1")
+            minari.download_dataset("D4RL/door/human-v2", force_download=True)
+        minari.delete_dataset("D4RL/door/human-v2")
 
     # 3. Check that the dataset version exists
     with pytest.raises(ValueError, match="doesn't exist in the remote Farama server."):
@@ -113,38 +113,38 @@ def test_download_error_messages(monkeypatch):
 
         return patched_get_remote
 
-    # Pretend that D4RL/door/human-v0 is compatible but D4RL/door/human-v1 is not
+    # Pretend that D4RL/door/human-v1 is compatible but D4RL/door/human-v2 is not
     with monkeypatch.context() as mp:
         mp.setattr(
             "minari.storage.hosting.get_remote_dataset_versions",
-            patch_get_remote_dataset_versions([[[0, 1], [0]], [[0], [0]]]),
+            patch_get_remote_dataset_versions([[[1, 2], [1]], [[1], [1]]]),
         )
 
         with pytest.raises(
             ValueError,
-            match="D4RL/door/human-v1, is not compatible with your local installed version of Minari",
+            match="D4RL/door/human-v2, is not compatible with your local installed version of Minari",
         ):
-            minari.download_dataset("D4RL/door/human-v1")
+            minari.download_dataset("D4RL/door/human-v2")
 
         with pytest.warns(
             match="will be FORCE download but you can download the latest compatible version of this dataset"
         ):
-            minari.download_dataset("D4RL/door/human-v1", force_download=True)
-        minari.delete_dataset("D4RL/door/human-v1")
+            minari.download_dataset("D4RL/door/human-v2", force_download=True)
+        minari.delete_dataset("D4RL/door/human-v2")
 
     # 5. Warning to recommend downloading the latest compatible version of the dataset
-    # Pretend that D4RL/door/human-v2 exists and try to download D4RL/door/human-v1
+    # Pretend that D4RL/door/human-v3 exists and try to download D4RL/door/human-v2
     with monkeypatch.context() as mp:
         mp.setattr(
             "minari.storage.hosting.get_remote_dataset_versions",
-            patch_get_remote_dataset_versions([[[1, 2], [1, 2]], [[2], [2]]]),
+            patch_get_remote_dataset_versions([[[2, 3], [2, 3]], [[3], [3]]]),
         )
 
         with pytest.warns(
             match="We recommend you install a higher dataset version available and compatible"
         ):
-            minari.download_dataset("D4RL/door/human-v1")
-        minari.delete_dataset("D4RL/door/human-v1")
+            minari.download_dataset("D4RL/door/human-v2")
+        minari.delete_dataset("D4RL/door/human-v2")
 
     # Skip datasets that exist locally
     latest_door_human_id = get_latest_compatible_dataset_id(

--- a/tests/dataset/test_dataset_download.py
+++ b/tests/dataset/test_dataset_download.py
@@ -46,7 +46,7 @@ def test_download_dataset_from_farama_server(dataset_id: str):
     dataset = minari.load_dataset(dataset_id)
     assert isinstance(dataset, MinariDataset)
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
 
     minari.delete_dataset(dataset_id)
     local_datasets = minari.list_local_datasets()

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -225,7 +225,7 @@ def test_minari_get_dataset_size_from_collector_env(
 
     assert dataset.storage.metadata["dataset_size"] == dataset.storage.get_size()
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
 
     env.close()
 
@@ -292,7 +292,7 @@ def test_minari_get_dataset_size_from_buffer(
 
     assert dataset.storage.metadata["dataset_size"] == dataset.storage.get_size()
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
 
     env.close()
 
@@ -318,7 +318,7 @@ def test_seed_change(tmp_dataset_dir, data_format):
     storage.update_episodes(episodes)
 
     assert storage.total_episodes == len(seeds)
-    episodes = storage.get_episodes(range(len(episodes)))
-    assert len(episodes) == len(seeds)
-    for seed, ep in zip(seeds, episodes):
-        assert ep["seed"] == seed
+    episodes_metadata = storage.get_episode_metadata(range(len(episodes)))
+    assert len(episodes_metadata) == len(seeds)
+    for seed, ep_metadata in zip(seeds, episodes_metadata):
+        assert ep_metadata.get("seed") == seed

--- a/tests/integrations/test_torch_rl.py
+++ b/tests/integrations/test_torch_rl.py
@@ -13,7 +13,7 @@ def test_torch_minari_experience_replay():
 
     batch_size = 32
 
-    dataset = MinariExperienceReplay("D4RL/door/human-v1", batch_size=batch_size)
+    dataset = MinariExperienceReplay("D4RL/door/human-v2", batch_size=batch_size)
     env = gym.make("AdroitHandDoor-v1")
 
     sample = dataset.sample()

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -135,7 +135,7 @@ def test_download_namespace_dataset():
     dataset = minari.load_dataset(kitchen_complete)
     assert isinstance(dataset, MinariDataset)
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
 
     minari.delete_dataset(kitchen_complete)
     assert set(minari.list_local_datasets().keys()) == {kitchen_mix}

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -74,7 +74,7 @@ def test_generate_dataset_with_collector_env(dataset_id, env_id, register_dummy_
     assert dataset.spec.total_episodes == num_episodes
     assert len(dataset.episode_indices) == num_episodes
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
     check_episode_data_integrity(
         dataset, dataset.spec.observation_space, dataset.spec.action_space
     )
@@ -134,7 +134,7 @@ def test_record_infos_collector_env(info_override, register_dummy_envs):
     assert dataset.spec.total_episodes == num_episodes
     assert len(dataset.episode_indices) == num_episodes
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
     check_episode_data_integrity(
         dataset,
         dataset.spec.observation_space,
@@ -219,7 +219,7 @@ def test_generate_dataset_with_external_buffer(
         assert dataset.spec.total_episodes == num_episodes
         assert len(dataset.episode_indices) == num_episodes
 
-        check_data_integrity(dataset.storage, dataset.episode_indices)
+        check_data_integrity(dataset, list(dataset.episode_indices))
         check_episode_data_integrity(
             dataset, dataset.spec.observation_space, dataset.spec.action_space
         )
@@ -321,7 +321,7 @@ def test_generate_dataset_with_space_subset_external_buffer(
     assert dataset.spec.total_episodes == num_episodes
     assert len(dataset.episode_indices) == num_episodes
 
-    check_data_integrity(dataset.storage, dataset.episode_indices)
+    check_data_integrity(dataset, list(dataset.episode_indices))
     check_episode_data_integrity(
         dataset, dataset.spec.observation_space, dataset.spec.action_space
     )


### PR DESCRIPTION
Move the seed attribute in episode_metadata. Thus, seed is not part of `EpisodeData` anymore.
The metadata is a better place for the seed as it is only needed for reproducibility, but not for training. Moreover, for tabular data like Arrow format, this was repeated for any step increasing the size of episode data. 

Finally, for reproducibility purposes, we also want to save reset option argument when present. Again, this will be saved in episode metadata.