### PR TITLE
fix dataset_id error on Windows

### DIFF
--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import os
+import pathlib
 import shutil
 import warnings
 from typing import Dict, Iterable, Tuple, Union
@@ -81,7 +82,7 @@ def list_local_datasets(
             namespaced_dir_name = os.path.join(namespace, dir_name)
             # Minari datasets must contain the data directory.
             if "data" in os.listdir(dir_path):
-                dataset_ids.append(namespaced_dir_name)
+                dataset_ids.append(pathlib.PurePath(namespaced_dir_name).as_posix())
             else:
                 recurse_directories(base_path, namespaced_dir_name)
 


### PR DESCRIPTION
# Description

Changed how to retrieve `dataset_id` from the path when listing local datasets. Previously, a string returned by `os.path.join` will be appended to the `dataset_ids`. However, this would break on Windows as Windows paths use backslash. Such `dataset_id` doesn't match the required pattern. This fix wraps the path string with `pathlib.PurePath` and converts it to posix path.

Fixes #238.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

Before
![Screenshot 2024-09-02 193110](https://github.com/user-attachments/assets/4ad55cf4-831b-4195-b511-41939b6f46cb)

After
![image](https://github.com/user-attachments/assets/b7c60ace-e7a1-4156-9871-1cc2e96db8f8)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
