### PR TITLE
Support heterogeneous dicts in infos

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -5,7 +5,9 @@ title: Basic Usage
 
 # Basic Usage
 
-Minari is a standard dataset hosting interface for Offline Reinforcement Learning applications. Minari is compatible with most of the RL environments that follow the Gymnasium API and facilitates Offline RL dataset handling by providing data collection, dataset hosting, and dataset sampling capabilities.
+Minari is a standard dataset hosting interface for Offline Reinforcement Learning applications. Minari is compatible
+with most of the RL environments that follow the Gymnasium API and facilitates Offline RL dataset handling by providing
+data collection, dataset hosting, and dataset sampling capabilities.
 
 ## Installation
 
@@ -15,7 +17,9 @@ To install the most recent version of the Minari library run this command:
 pip install minari
 ```
 
-This will install the minimum required dependencies. Additional dependencies will be prompted for installation based on your use case. To install all dependencies at once, use:
+This will install the minimum required dependencies. Additional dependencies will be prompted for installation based on
+your use case. To install all dependencies at once, use:
+
 ```bash
 pip install "minari[all]"
 ```
@@ -53,14 +57,14 @@ minari list remote
 │             ...                │       ...      │     ...     │     ...      │       ...       │
 ```
 
-To use your own server with Minari, set the `MINARI_REMOTE` environment variable in the format `remote-type://remote-path`. For example, to set up a GCP bucket named `my-datasets`, run the following command:
+To use your own server with Minari, set the `MINARI_REMOTE` environment variable in the format
+`remote-type://remote-path`. For example, to set up a GCP bucket named `my-datasets`, run the following command:
 
 ```bash
 export MINARI_REMOTE=gcp://my-datasets
 ```
 
 Currently, only GCP is supported, but we plan to support other cloud providers in the future.
-
 
 ```{eval-rst}
 To download any of the remote datasets into the local storage use the download command:
@@ -95,12 +99,14 @@ In order to use any of the dataset sampling features of Minari we first need to 
 
 ```python
 import minari
+
 dataset = minari.load_dataset('D4RL/door/human-v2')
 print("Observation space:", dataset.observation_space)
 print("Action space:", dataset.action_space)
 print("Total episodes:", dataset.total_episodes)
 print("Total steps:", dataset.total_steps)
 ```
+
 ```
 Observation space: Box(-inf, inf, (39,), float64)
 Action space: Box(-1.0, 1.0, (28,), float32)
@@ -180,7 +186,6 @@ for episode in dataset:
     print(f"EPISODE ID {episode.id}")
 ```
 
-
 #### Filter Episodes
 
 ```{eval-rst}
@@ -248,7 +253,6 @@ for _ in range(100):
         env.reset()
 ```
 
-
 ```{eval-rst}
 
 .. note::
@@ -275,6 +279,7 @@ minari download D4RL/door/expert-v2
 minari combine D4RL/door/human-v2 D4RL/door/expert-v2 --dataset-id=D4RL/door/all-v0
 minari list local
 ```
+
 ```
                     Local Minari datasets('/Users/farama/.minari/datasets/')
 ┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
@@ -307,8 +312,10 @@ env = DataCollector(env, record_infos=True)
 ```{eval-rst}
 In this example, the :class:`minari.DataCollector` wraps the `'CartPole-v1'` environment from Gymnasium. We set ``record_infos=True`` so the wrapper will also collect the returned ``info`` dictionaries to create the dataset. For the full list of arguments, read the :class:`minari.DataCollector` documentation.
 ```
-Infos can be saved as a dictionary of np.arrays or as a list of arbitrary dictionaries by 
+
+Infos can be saved as a dictionary of np.arrays or as a list of arbitrary dictionaries by
 setting the `infos_format` parameter. Default is dictionary format `infos_format = None or "dict"`:
+
 ```python
 from minari import DataCollector
 import gymnasium as gym
@@ -367,6 +374,7 @@ Once the dataset has been created we can check if the Minari dataset id appears 
 ```bash
 minari list local
 ```
+
 ```
         Local Minari datasets('/Users/farama/.minari/datasets/')
 ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┓
@@ -428,7 +436,6 @@ for episode_id in range(total_episodes):
         else:
             env.add_to_dataset(dataset)
 ```
-
 
 ## Using Namespaces
 

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -307,6 +307,15 @@ env = DataCollector(env, record_infos=True)
 ```{eval-rst}
 In this example, the :class:`minari.DataCollector` wraps the `'CartPole-v1'` environment from Gymnasium. We set ``record_infos=True`` so the wrapper will also collect the returned ``info`` dictionaries to create the dataset. For the full list of arguments, read the :class:`minari.DataCollector` documentation.
 ```
+Infos can be saved as a dictionary of np.arrays or as a list of arbitrary dictionaries by 
+setting the `infos_format` parameter. Default is dictionary format `infos_format = None or "dict"`:
+```python
+from minari import DataCollector
+import gymnasium as gym
+
+env = gym.make('CartPole-v1')
+env = DataCollector(env, record_infos=True, infos_format="list")
+```
 
 ### Save Dataset
 

--- a/docs/content/dataset_standards.md
+++ b/docs/content/dataset_standards.md
@@ -92,15 +92,15 @@ sampled_episodes = dataset.sample_episodes(10)
 
 The `sampled_episodes` variable will be a list of 10 `EpisodeData` elements, each containing episode data. An `EpisodeData` element is a data class consisting of the following fields:
 
-| Field             | Type                                 | Description                                                   |
-| ----------------- | ------------------------------------ | ------------------------------------------------------------- |
-| `id`              | `int`                           | ID of the episode.                                            |
-| `observations`    | `np.ndarray`, `list`, `tuple`, `dict` | Stacked observations for each step including initial observation.    |
-| `actions`         | `np.ndarray`, `list`, `tuple`, `dict` | Stacked actions for each step.                                       |
-| `rewards`         | `np.ndarray`                         | Rewards for each step.                                        |
-| `terminations`    | `np.ndarray`                         | Terminations for each step.                                   |
-| `truncations`     | `np.ndarray`                         | Truncations for each step.                                    |
-| `infos`           | `dict`                               | A dictionary containing additional information returned by the environment             |
+| Field             | Type                                  | Description                                                                                                                        |
+| ----------------- |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `id`              | `int`                                 | ID of the episode.                                                                                                                 |
+| `observations`    | `np.ndarray`, `list`, `tuple`, `dict` | Stacked observations for each step including initial observation.                                                                  |
+| `actions`         | `np.ndarray`, `list`, `tuple`, `dict` | Stacked actions for each step.                                                                                                     |
+| `rewards`         | `np.ndarray`                          | Rewards for each step.                                                                                                             |
+| `terminations`    | `np.ndarray`                          | Terminations for each step.                                                                                                        |
+| `truncations`     | `np.ndarray`                          | Truncations for each step.                                                                                                         |
+| `infos`           | `dict`, `list`                         | A dictionary of iterables (e.g. list, array) or list of dictionaries containing additional information returned by the environment |
 
 As mentioned in the `Supported Spaces` section, many different observation and action spaces are supported so the data type for these fields are dependent on the environment being used.
 

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -160,7 +160,7 @@ class DataCollector(gym.Wrapper):
             self._buffer = EpisodeBuffer(
                 id=self._episode_id,
                 observations=step_data["observation"],
-                infos=step_data["info"],
+                infos=[step_data["info"]],
             )
 
         return obs, rew, terminated, truncated, info
@@ -206,7 +206,7 @@ class DataCollector(gym.Wrapper):
             seed=seed,
             options=options,
             observations=step_data["observation"],
-            infos=step_data["info"] if self._record_infos else None,
+            infos=[step_data["info"]] if self._record_infos else None,
         )
         return obs, info
 

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -20,7 +20,6 @@ from minari.dataset.minari_storage import MinariStorage
 from minari.namespace import create_namespace, list_local_namespaces
 from minari.utils import _generate_dataset_metadata, _generate_dataset_path
 
-
 # H5Py supports ints up to uint64
 AUTOSEED_BIT_SIZE = 64
 
@@ -163,7 +162,11 @@ class DataCollector(gym.Wrapper):
             self._buffer = EpisodeBuffer(
                 id=self._episode_id,
                 observations=step_data["observation"],
-                infos=step_data["info"] if self.infos_format == "dict" else [step_data["info"]],
+                infos=(
+                    step_data["info"]
+                    if self.infos_format == "dict"
+                    else [step_data["info"]]
+                ),
             )
 
         return obs, rew, terminated, truncated, info
@@ -210,7 +213,11 @@ class DataCollector(gym.Wrapper):
             seed=seed,
             options=options,
             observations=step_data["observation"],
-            infos=infos if self.infos_format == "dict" else [infos] if infos is not None else None,
+            infos=(
+                infos
+                if self.infos_format == "dict"
+                else [infos] if infos is not None else None
+            ),
         )
         return obs, info
 

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -20,6 +20,7 @@ from minari.dataset.minari_storage import MinariStorage
 from minari.namespace import create_namespace, list_local_namespaces
 from minari.utils import _generate_dataset_metadata, _generate_dataset_path
 
+
 # H5Py supports ints up to uint64
 AUTOSEED_BIT_SIZE = 64
 

--- a/minari/data_collector/episode_buffer.py
+++ b/minari/data_collector/episode_buffer.py
@@ -18,7 +18,7 @@ class EpisodeBuffer:
     rewards: list = field(default_factory=list)
     terminations: list = field(default_factory=list)
     truncations: list = field(default_factory=list)
-    infos: Optional[dict] = None
+    infos: Optional[list] = field(default_factory=list)
 
     def add_step_data(self, step_data: StepData) -> EpisodeBuffer:
         """Add step data dictionary to episode buffer.
@@ -54,11 +54,7 @@ class EpisodeBuffer:
         else:
             actions = jtu.tree_map(_append, step_data["action"], self.actions)
 
-        if self.infos is None:
-            infos = jtu.tree_map(lambda x: [x], step_data["info"])
-        else:
-            infos = jtu.tree_map(_append, step_data["info"], self.infos)
-
+        self.infos.append(step_data["info"])
         self.rewards.append(step_data["reward"])
         self.terminations.append(step_data["termination"])
         self.truncations.append(step_data["truncation"])
@@ -72,7 +68,7 @@ class EpisodeBuffer:
             rewards=self.rewards,
             terminations=self.terminations,
             truncations=self.truncations,
-            infos=infos,
+            infos=self.infos,
         )
 
     def __len__(self) -> int:

--- a/minari/data_collector/episode_buffer.py
+++ b/minari/data_collector/episode_buffer.py
@@ -54,7 +54,8 @@ class EpisodeBuffer:
         else:
             actions = jtu.tree_map(_append, step_data["action"], self.actions)
 
-        self.infos.append(step_data["info"])
+        if self.infos is not None:
+            self.infos.append(step_data["info"])
         self.rewards.append(step_data["reward"])
         self.terminations.append(step_data["termination"])
         self.truncations.append(step_data["truncation"])

--- a/minari/data_collector/episode_buffer.py
+++ b/minari/data_collector/episode_buffer.py
@@ -57,7 +57,11 @@ class EpisodeBuffer:
 
         infos_format = infos_format or "dict"
         if self.infos is None:
-            infos = jtu.tree_map(lambda x: [x], step_data["info"]) if infos_format == "dict" else [step_data["info"]]
+            infos = (
+                jtu.tree_map(lambda x: [x], step_data["info"])
+                if infos_format == "dict"
+                else [step_data["info"]]
+            )
         else:
             if isinstance(self.infos, dict):
                 infos = jtu.tree_map(_append, step_data["info"], self.infos)
@@ -66,7 +70,6 @@ class EpisodeBuffer:
                 infos = self.infos
             else:
                 raise ValueError(f"Unexpected type for infos: {type(self.infos)}")
-
 
         self.rewards.append(step_data["reward"])
         self.terminations.append(step_data["termination"])

--- a/minari/dataset/_storages/arrow_storage.py
+++ b/minari/dataset/_storages/arrow_storage.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence
 import gymnasium as gym
 import numpy as np
 
-
 try:
     import pyarrow as pa
     import pyarrow.dataset as ds
@@ -105,7 +104,9 @@ class ArrowStorage(MinariStorage):
 
             return {
                 "id": id,
-                "observations": _decode_space(self.observation_space, episode["observations"]),
+                "observations": _decode_space(
+                    self.observation_space, episode["observations"]
+                ),
                 "actions": _decode_space(self.action_space, episode["actions"][:-1]),
                 "rewards": np.asarray(episode["rewards"])[:-1],
                 "terminations": np.asarray(episode["terminations"])[:-1],

--- a/minari/dataset/_storages/arrow_storage.py
+++ b/minari/dataset/_storages/arrow_storage.py
@@ -4,10 +4,11 @@ import json
 import pathlib
 from collections.abc import Iterable as ABCIterable
 from itertools import zip_longest
-from typing import Any, Dict, Iterable, Optional, Sequence, List
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import gymnasium as gym
 import numpy as np
+
 
 try:
     import pyarrow as pa
@@ -18,39 +19,43 @@ except ImportError:
     )
 
 from minari.data_collector.episode_buffer import EpisodeBuffer
+from minari.dataset._storages.serde import (
+    NumpyEncoder,
+    deserialize_dict,
+    serialize_dict,
+)
 from minari.dataset.minari_storage import MinariStorage
-from minari.dataset._storages.serde import NumpyEncoder, serialize_dict, deserialize_dict
 
 
 class ArrowStorage(MinariStorage):
     FORMAT = "arrow"
 
     def __init__(
-            self,
-            data_path: pathlib.Path,
-            observation_space: gym.Space,
-            action_space: gym.Space,
+        self,
+        data_path: pathlib.Path,
+        observation_space: gym.Space,
+        action_space: gym.Space,
     ):
         super().__init__(data_path, observation_space, action_space)
 
     @classmethod
     def _create(
-            cls,
-            data_path: pathlib.Path,
-            observation_space: gym.Space,
-            action_space: gym.Space,
+        cls,
+        data_path: pathlib.Path,
+        observation_space: gym.Space,
+        action_space: gym.Space,
     ) -> MinariStorage:
         return cls(data_path, observation_space, action_space)
 
     def update_episode_metadata(
-            self, metadatas: Iterable[Dict], episode_indices: Optional[Iterable] = None
+        self, metadatas: Iterable[Dict], episode_indices: Optional[Iterable] = None
     ):
         if episode_indices is None:
             episode_indices = range(self.total_episodes)
 
         sentinel = object()
         for new_metadata, episode_id in zip_longest(
-                metadatas, episode_indices, fillvalue=sentinel
+            metadatas, episode_indices, fillvalue=sentinel
         ):
             if sentinel in (new_metadata, episode_id):
                 raise ValueError("Metadatas and episode_indices have different lengths")
@@ -143,7 +148,9 @@ class ArrowStorage(MinariStorage):
                     episode_batch["infos"] = _encode_info(episode_data.infos)
                 elif isinstance(episode_data.infos, list):
                     info_pad = len(observations) - len(episode_data.infos)
-                    episode_batch["infos"] = encode_info_list(episode_data.infos + [episode_data.infos[-1]] * info_pad)
+                    episode_batch["infos"] = encode_info_list(
+                        episode_data.infos + [episode_data.infos[-1]] * info_pad
+                    )
 
             episode_batch = pa.RecordBatch.from_pydict(episode_batch)
 
@@ -241,7 +248,7 @@ def _encode_info(info: dict):
             fields.append(pa.field(key, array.type))
 
         elif isinstance(values, np.ndarray) or (
-                isinstance(values, Sequence) and isinstance(values[0], np.ndarray)
+            isinstance(values, Sequence) and isinstance(values[0], np.ndarray)
         ):
             if isinstance(values, Sequence):
                 values = np.stack(values)

--- a/minari/dataset/_storages/arrow_storage.py
+++ b/minari/dataset/_storages/arrow_storage.py
@@ -26,31 +26,31 @@ class ArrowStorage(MinariStorage):
     FORMAT = "arrow"
 
     def __init__(
-        self,
-        data_path: pathlib.Path,
-        observation_space: gym.Space,
-        action_space: gym.Space,
+            self,
+            data_path: pathlib.Path,
+            observation_space: gym.Space,
+            action_space: gym.Space,
     ):
         super().__init__(data_path, observation_space, action_space)
 
     @classmethod
     def _create(
-        cls,
-        data_path: pathlib.Path,
-        observation_space: gym.Space,
-        action_space: gym.Space,
+            cls,
+            data_path: pathlib.Path,
+            observation_space: gym.Space,
+            action_space: gym.Space,
     ) -> MinariStorage:
         return cls(data_path, observation_space, action_space)
 
     def update_episode_metadata(
-        self, metadatas: Iterable[Dict], episode_indices: Optional[Iterable] = None
+            self, metadatas: Iterable[Dict], episode_indices: Optional[Iterable] = None
     ):
         if episode_indices is None:
             episode_indices = range(self.total_episodes)
 
         sentinel = object()
         for new_metadata, episode_id in zip_longest(
-            metadatas, episode_indices, fillvalue=sentinel
+                metadatas, episode_indices, fillvalue=sentinel
         ):
             if sentinel in (new_metadata, episode_id):
                 raise ValueError("Metadatas and episode_indices have different lengths")
@@ -90,7 +90,7 @@ class ArrowStorage(MinariStorage):
             if "infos" in episode.column_names:
                 try:
                     infos = decode_info_list(episode["infos"])
-                except Exception as e:  # for backwards compatibility
+                except:  # noqa for backwards compatibility
                     try:
                         infos = _decode_info(episode["infos"])
                     except Exception as e:
@@ -143,7 +143,7 @@ class ArrowStorage(MinariStorage):
                     episode_batch["infos"] = _encode_info(episode_data.infos)
                 elif isinstance(episode_data.infos, list):
                     info_pad = len(observations) - len(episode_data.infos)
-                    episode_batch["infos"] = encode_info_list(episode_data.infos + [episode_data.infos[-1]]*info_pad)
+                    episode_batch["infos"] = encode_info_list(episode_data.infos + [episode_data.infos[-1]] * info_pad)
 
             episode_batch = pa.RecordBatch.from_pydict(episode_batch)
 
@@ -241,7 +241,7 @@ def _encode_info(info: dict):
             fields.append(pa.field(key, array.type))
 
         elif isinstance(values, np.ndarray) or (
-            isinstance(values, Sequence) and isinstance(values[0], np.ndarray)
+                isinstance(values, Sequence) and isinstance(values[0], np.ndarray)
         ):
             if isinstance(values, Sequence):
                 values = np.stack(values)
@@ -287,4 +287,3 @@ def encode_info_list(info_list: List[Dict[str, Any]]) -> pa.Array:
 
 def decode_info_list(values: pa.Array) -> List[Dict[str, Any]]:
     return [deserialize_dict(item.as_py()) for item in values]
-

--- a/minari/dataset/_storages/arrow_storage.py
+++ b/minari/dataset/_storages/arrow_storage.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence
 import gymnasium as gym
 import numpy as np
 
+
 try:
     import pyarrow as pa
     import pyarrow.dataset as ds

--- a/minari/dataset/_storages/arrow_storage.py
+++ b/minari/dataset/_storages/arrow_storage.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Iterable, Optional, Sequence, List
 import gymnasium as gym
 import numpy as np
 
-
 try:
     import pyarrow as pa
     import pyarrow.dataset as ds
@@ -19,6 +18,7 @@ except ImportError:
 
 from minari.data_collector.episode_buffer import EpisodeBuffer
 from minari.dataset.minari_storage import MinariStorage
+from minari.dataset._storages.serde import NumpyEncoder, serialize_dict, deserialize_dict
 
 
 class ArrowStorage(MinariStorage):
@@ -93,7 +93,7 @@ class ArrowStorage(MinariStorage):
                     except Exception as e:
                         raise ValueError(f"Failed to decode infos: {e}")
             else:
-                infos = {}
+                infos = []
 
             return {
                 "id": id,
@@ -264,94 +264,11 @@ def _decode_info(values: pa.Array):
     return nested_dict
 
 
-def encode_info_list(info_list: List[Dict[str, Any]]):
-    if not info_list:
-        return pa.StructArray.from_arrays([], fields=[])
-
-    # Collect all unique keys
-    all_keys = set()
-    for d in info_list:
-        all_keys.update(d.keys())
-
-    arrays, fields = [], []
-    for key in all_keys:
-        values = [d.get(key) for d in info_list]
-
-        # Handle missing values
-        if all(v is None for v in values):
-            arrays.append(pa.array(values))
-            fields.append(pa.field(key, pa.null()))
-            continue
-
-        sample_value = next(v for v in values if v is not None)
-
-        if isinstance(sample_value, dict):
-            nested_list = [{k: v.get(k) if v is not None else None for k in sample_value.keys()} for v in values]
-            array = encode_info_list(nested_list)
-            arrays.append(array)
-            fields.append(pa.field(key, array.type))
-        elif isinstance(sample_value, tuple):
-            nested_list = [{str(i): v[i] if v is not None else None for i in range(len(sample_value))} for v in values]
-            array = encode_info_list(nested_list)
-            arrays.append(array)
-            fields.append(pa.field(key, array.type))
-        elif isinstance(sample_value, np.ndarray) or (
-                isinstance(sample_value, Sequence) and isinstance(sample_value[0], np.ndarray)
-        ):
-            # Handle potential None values
-            valid_values = [v for v in values if v is not None]
-            if isinstance(sample_value, Sequence):
-                valid_values = np.stack(valid_values)
-            else:
-                valid_values = np.array(valid_values)
-            data_shape = valid_values.shape[1:]
-            valid_values = valid_values.reshape(len(valid_values), -1)
-            dtype = pa.from_numpy_dtype(valid_values.dtype)
-            struct = pa.list_(dtype, list_size=valid_values.shape[1])
-            array = pa.FixedSizeListArray.from_arrays(valid_values.reshape(-1), type=struct)
-            # Handle None values
-            mask = [v is not None for v in values]
-            array = array.fill_null(pa.null())
-            array = array.filter(mask)
-            arrays.append(array)
-            fields.append(pa.field(key, struct, metadata={"shape": bytes(data_shape)}))
-        else:
-            array = pa.array(values)
-            arrays.append(array)
-            fields.append(pa.field(key, array.type))
-
-    return pa.StructArray.from_arrays(arrays, fields=fields)
+def encode_info_list(info_list: List[Dict[str, Any]]) -> pa.Array:
+    serialized_list = [serialize_dict(d) for d in info_list]
+    return pa.array(serialized_list, type=pa.string())
 
 
 def decode_info_list(values: pa.Array) -> List[Dict[str, Any]]:
-    result = []
-    for i in range(len(values)):
-        nested_dict = {}
-        for j, field in enumerate(values.type):
-            if pa.types.is_struct(field.type):
-                nested_value = decode_info_list(values.field(j)[i])
-                if len(nested_value) == 1:
-                    nested_dict[field.name] = nested_value[0]
-                else:
-                    nested_dict[field.name] = nested_value
-            else:
-                value = values.field(j)[i]
-                if value is None:
-                    continue
-                if isinstance(value, pa.FixedSizeListArray):
-                    value = np.array(value.to_numpy(zero_copy_only=False))
-                    if field.metadata is not None and b"shape" in field.metadata:
-                        data_shape = tuple(field.metadata[b"shape"])
-                        value = value.reshape(data_shape)
-                else:
-                    value = value.as_py()
-                nested_dict[field.name] = value
-        result.append(nested_dict)
-    return result
+    return [deserialize_dict(item.as_py()) for item in values]
 
-
-class NumpyEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        return super().default(obj)

--- a/minari/dataset/_storages/hdf5_storage.py
+++ b/minari/dataset/_storages/hdf5_storage.py
@@ -10,8 +10,8 @@ import gymnasium as gym
 import numpy as np
 
 from minari.data_collector import EpisodeBuffer
-from minari.dataset.minari_storage import MinariStorage
 from minari.dataset._storages.serde import serialize_dict, deserialize_dict
+from minari.dataset.minari_storage import MinariStorage
 
 try:
     import h5py
@@ -27,10 +27,10 @@ class HDF5Storage(MinariStorage):
     FORMAT = "hdf5"
 
     def __init__(
-        self,
-        data_path: pathlib.Path,
-        observation_space: gym.Space,
-        action_space: gym.Space,
+            self,
+            data_path: pathlib.Path,
+            observation_space: gym.Space,
+            action_space: gym.Space,
     ):
         super().__init__(data_path, observation_space, action_space)
         file_path = self.data_path.joinpath(_MAIN_FILE_NAME)
@@ -40,17 +40,17 @@ class HDF5Storage(MinariStorage):
 
     @classmethod
     def _create(
-        cls,
-        data_path: pathlib.Path,
-        observation_space: gym.Space,
-        action_space: gym.Space,
+            cls,
+            data_path: pathlib.Path,
+            observation_space: gym.Space,
+            action_space: gym.Space,
     ) -> MinariStorage:
         data_path.joinpath(_MAIN_FILE_NAME).touch(exist_ok=False)
         obj = cls(data_path, observation_space, action_space)
         return obj
 
     def update_episode_metadata(
-        self, metadatas: Iterable[Dict], episode_indices: Optional[Iterable] = None
+            self, metadatas: Iterable[Dict], episode_indices: Optional[Iterable] = None
     ):
         if episode_indices is None:
             episode_indices = range(self.total_episodes)
@@ -58,7 +58,7 @@ class HDF5Storage(MinariStorage):
         sentinel = object()
         with h5py.File(self._file_path, "a") as file:
             for metadata, episode_id in zip_longest(
-                metadatas, episode_indices, fillvalue=sentinel
+                    metadatas, episode_indices, fillvalue=sentinel
             ):
                 if sentinel in (metadata, episode_id):
                     raise ValueError(
@@ -84,9 +84,9 @@ class HDF5Storage(MinariStorage):
                 yield metadata
 
     def _decode_space(
-        self,
-        hdf_ref: Union[h5py.Group, h5py.Dataset, h5py.Datatype],
-        space: gym.spaces.Space,
+            self,
+            hdf_ref: Union[h5py.Group, h5py.Dataset, h5py.Datatype],
+            space: gym.spaces.Space,
     ) -> Union[Dict, Tuple, List, np.ndarray]:
         assert not isinstance(hdf_ref, h5py.Datatype)
 
@@ -121,7 +121,7 @@ class HDF5Storage(MinariStorage):
                 if "infos" in ep_group:
                     info_group = ep_group["infos"]
                     if isinstance(info_group, h5py.Group):  # for backward compatibility
-                         infos = _decode_info(info_group)
+                        infos = _decode_info(info_group)
                     else:
                         infos = read_dict_dataset_from_group(ep_group, "infos")
 
@@ -149,7 +149,7 @@ class HDF5Storage(MinariStorage):
                 total_episodes = len(file.keys())
                 episode_id = eps_buff.id if eps_buff.id is not None else total_episodes
                 assert (
-                    episode_id <= total_episodes
+                        episode_id <= total_episodes
                 ), "Invalid episode id; ids must be sequential."
                 episode_group = _get_from_h5py(file, f"episode_{episode_id}")
                 episode_group.attrs["id"] = episode_id
@@ -210,7 +210,7 @@ def _add_episode_to_group(episode_buffer: Dict, episode_group: h5py.Group):
             episode_group_to_clear = _get_from_h5py(episode_group, key)
             _add_episode_to_group(dict_data, episode_group_to_clear)
         elif isinstance(data, List) and all(
-            isinstance(entry, OrderedDict) for entry in data
+                isinstance(entry, OrderedDict) for entry in data
         ):  # list of OrderedDict
             dict_data = {key: [entry[key] for entry in data] for key in data[0].keys()}
             episode_group_to_clear = _get_from_h5py(episode_group, key)
@@ -221,7 +221,7 @@ def _add_episode_to_group(episode_buffer: Dict, episode_group: h5py.Group):
             dataset = episode_group[key]
             assert isinstance(dataset, h5py.Dataset)
             dataset.resize((dataset.shape[0] + len(data), *dataset.shape[1:]))
-            dataset[-len(data) :] = data
+            dataset[-len(data):] = data
         elif not isinstance(data, Iterable):
             if data is not None:
                 episode_group.create_dataset(key, data=data)
@@ -328,6 +328,7 @@ def create_dict_dataset_in_group(group, dataset_name, dict_list: List[Dict[str, 
     dataset = group.create_dataset(dataset_name, (len(serialized_list),), dtype=dt)
     dataset[:] = serialized_list
     return dataset
+
 
 def read_dict_dataset_from_group(group, dataset_name):
     dataset = group[dataset_name]

--- a/minari/dataset/_storages/hdf5_storage.py
+++ b/minari/dataset/_storages/hdf5_storage.py
@@ -193,7 +193,10 @@ def _get_from_h5py(group: h5py.Group, name: str) -> h5py.Group:
 
 def _add_episode_to_group(episode_buffer: Dict, episode_group: h5py.Group):
     for key, data in episode_buffer.items():
-        if isinstance(data, dict):
+
+        if key == "infos":
+            create_dict_dataset_in_group(episode_group, "infos", data)
+        elif isinstance(data, dict):
             episode_group_to_clear = _get_from_h5py(episode_group, key)
             _add_episode_to_group(data, episode_group_to_clear)
         elif isinstance(data, tuple):
@@ -216,12 +219,6 @@ def _add_episode_to_group(episode_buffer: Dict, episode_group: h5py.Group):
         elif not isinstance(data, Iterable):
             if data is not None:
                 episode_group.create_dataset(key, data=data)
-
-        elif key == "infos":
-            print("infos", type(data))
-            print(data)
-
-            create_dict_dataset_in_group(episode_group, "infos", data)
         else:
             dtype = None
             if all(map(lambda elem: isinstance(elem, str), data)):
@@ -320,7 +317,7 @@ def serialize_value(value):
 
 
 def create_dict_dataset_in_group(group, dataset_name, dict_list: List[Dict[str, Any]]):
-    serialized_list = [serialize_dict(d) for d in dict_list]
+    serialized_list = [serialize_dict(d) for d in dict_list] if dict_list else []
     dt = h5py.special_dtype(vlen=str)
     dataset = group.create_dataset(dataset_name, (len(serialized_list),), dtype=dt)
     dataset[:] = serialized_list

--- a/minari/dataset/_storages/hdf5_storage.py
+++ b/minari/dataset/_storages/hdf5_storage.py
@@ -201,7 +201,7 @@ def _get_from_h5py(group: h5py.Group, name: str) -> h5py.Group:
 def _add_episode_to_group(episode_buffer: Dict, episode_group: h5py.Group):
     for key, data in episode_buffer.items():
 
-        if key == "infos":
+        if key == "infos" and isinstance(data, List):
             create_dict_dataset_in_group(episode_group, "infos", data)
         elif isinstance(data, dict):
             episode_group_to_clear = _get_from_h5py(episode_group, key)

--- a/minari/dataset/_storages/serde.py
+++ b/minari/dataset/_storages/serde.py
@@ -16,13 +16,16 @@ class NumpyEncoder(json.JSONEncoder):
 
         return super().default(obj)
 
+
 try:
     import orjson
+
     dumps = partial(orjson.dumps, option=orjson.OPT_SERIALIZE_NUMPY)
     loads = orjson.loads
 except ImportError:
     loads = json.loads
-    dumps = partial(json.dumps,cls=NumpyEncoder)
+    dumps = partial(json.dumps, cls=NumpyEncoder)
+
 
 def serialize_dict(data: Dict[str, Any]):
     return dumps(data)

--- a/minari/dataset/_storages/serde.py
+++ b/minari/dataset/_storages/serde.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 from functools import partial
-from typing import Dict, Any
+from typing import Any, Dict
 
 import numpy as np
+
 
 class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/minari/dataset/_storages/serde.py
+++ b/minari/dataset/_storages/serde.py
@@ -23,9 +23,9 @@ except ImportError:
     loads = json.loads
     dumps = partial(json.dumps,cls=NumpyEncoder)
 
-def serialize_dict(data: Dict[str, Any]) -> bytes:
+def serialize_dict(data: Dict[str, Any]):
     return dumps(data)
 
 
 def deserialize_dict(serialized_data: str) -> Dict[str, Any]:
-    return orjson.loads(serialized_data)
+    return loads(serialized_data)

--- a/minari/dataset/_storages/serde.py
+++ b/minari/dataset/_storages/serde.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, Any
+
+import numpy as np
+
+
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, (np.integer, np.floating)):
+            return obj.item()
+        return super().default(obj)
+
+
+def serialize_dict(data: Dict[str, Any]) -> str:
+    return json.dumps(data, cls=NumpyEncoder)
+
+
+def deserialize_dict(serialized_data: str) -> Dict[str, Any]:
+    return json.loads(serialized_data)

--- a/minari/dataset/_storages/serde.py
+++ b/minari/dataset/_storages/serde.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import json
+from functools import partial
 from typing import Dict, Any
 
 import numpy as np
-
 
 class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -12,12 +12,20 @@ class NumpyEncoder(json.JSONEncoder):
             return obj.tolist()
         if isinstance(obj, (np.integer, np.floating)):
             return obj.item()
+
         return super().default(obj)
 
+try:
+    import orjson
+    dumps = partial(orjson.dumps, option=orjson.OPT_SERIALIZE_NUMPY)
+    loads = orjson.loads
+except ImportError:
+    loads = json.loads
+    dumps = partial(json.dumps,cls=NumpyEncoder)
 
-def serialize_dict(data: Dict[str, Any]) -> str:
-    return json.dumps(data, cls=NumpyEncoder)
+def serialize_dict(data: Dict[str, Any]) -> bytes:
+    return dumps(data)
 
 
 def deserialize_dict(serialized_data: str) -> Dict[str, Any]:
-    return json.loads(serialized_data)
+    return orjson.loads(serialized_data)

--- a/minari/dataset/episode_data.py
+++ b/minari/dataset/episode_data.py
@@ -14,12 +14,19 @@ class EpisodeData:
     rewards: np.ndarray
     terminations: np.ndarray
     truncations: np.ndarray
-    infos: dict
+    infos: dict | list  # dict is for backwards compatibility
 
     def __len__(self) -> int:
         return len(self.rewards)
 
     def __repr__(self) -> str:
+        if isinstance(self.infos, dict):
+            infos_repr = f"infos=dict with the following keys: {list(self.infos.keys())}"
+        elif isinstance(self.infos, list):
+            infos_repr = (f"infos=list of dicts with the following keys: "
+                          f"{set(key for d in self.infos for key in d.keys())}")
+        else:
+            raise ValueError(f"Unexpected type for infos: {type(self.infos)}")
         return (
             "EpisodeData("
             f"id={self.id}, "
@@ -29,7 +36,7 @@ class EpisodeData:
             f"rewards=ndarray of {len(self.rewards)} floats, "
             f"terminations=ndarray of {len(self.terminations)} bools, "
             f"truncations=ndarray of {len(self.truncations)} bools, "
-            f"infos=dict with the following keys: {list(self.infos.keys())}"
+            f"{infos_repr}"            
             ")"
         )
 

--- a/minari/dataset/episode_data.py
+++ b/minari/dataset/episode_data.py
@@ -38,7 +38,7 @@ class EpisodeData:
             f"rewards=ndarray of {len(self.rewards)} floats, "
             f"terminations=ndarray of {len(self.terminations)} bools, "
             f"truncations=ndarray of {len(self.truncations)} bools, "
-            f"{infos_repr}"            
+            f"{infos_repr}"
             ")"
         )
 

--- a/minari/dataset/episode_data.py
+++ b/minari/dataset/episode_data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, List, Union
 
 import numpy as np
 
@@ -14,7 +14,7 @@ class EpisodeData:
     rewards: np.ndarray
     terminations: np.ndarray
     truncations: np.ndarray
-    infos: dict | list  # dict is for backwards compatibility
+    infos: Union[Dict | List]  # dict is for backwards compatibility
 
     def __len__(self) -> int:
         return len(self.rewards)

--- a/minari/dataset/episode_data.py
+++ b/minari/dataset/episode_data.py
@@ -21,10 +21,14 @@ class EpisodeData:
 
     def __repr__(self) -> str:
         if isinstance(self.infos, dict):
-            infos_repr = f"infos=dict with the following keys: {list(self.infos.keys())}"
+            infos_repr = (
+                f"infos=dict with the following keys: {list(self.infos.keys())}"
+            )
         elif isinstance(self.infos, list):
-            infos_repr = (f"infos=list of dicts with the following keys: "
-                          f"{set(key for d in self.infos for key in d.keys())}")
+            infos_repr = (
+                f"infos=list of dicts with the following keys: "
+                f"{set(key for d in self.infos for key in d.keys())}"
+            )
         elif self.infos is None:
             infos_repr = "infos=None"
         else:

--- a/minari/dataset/episode_data.py
+++ b/minari/dataset/episode_data.py
@@ -25,6 +25,8 @@ class EpisodeData:
         elif isinstance(self.infos, list):
             infos_repr = (f"infos=list of dicts with the following keys: "
                           f"{set(key for d in self.infos for key in d.keys())}")
+        elif self.infos is None:
+            infos_repr = "infos=None"
         else:
             raise ValueError(f"Unexpected type for infos: {type(self.infos)}")
         return (

--- a/minari/dataset/episode_data.py
+++ b/minari/dataset/episode_data.py
@@ -14,7 +14,7 @@ class EpisodeData:
     rewards: np.ndarray
     terminations: np.ndarray
     truncations: np.ndarray
-    infos: Union[Dict | List]  # dict is for backwards compatibility
+    infos: Union[Dict, List]  # dict is for backwards compatibility
 
     def __len__(self) -> int:
         return len(self.rewards)

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -14,6 +14,7 @@ from gymnasium.envs.registration import EnvSpec
 from minari.data_collector.episode_buffer import EpisodeBuffer
 from minari.serialization import deserialize_space, serialize_space
 
+
 PathLike = Union[str, os.PathLike]
 METADATA_FILE_NAME = "metadata.json"
 
@@ -325,7 +326,7 @@ class MinariStorage(ABC):
                 rewards=episode["rewards"],
                 terminations=episode["terminations"],
                 truncations=episode["truncations"],
-                infos=episode.get("infos",[]),
+                infos=episode.get("infos", []),
             )
             self.update_episodes([episode_buffer])
 

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -326,7 +326,7 @@ class MinariStorage(ABC):
                 rewards=episode["rewards"],
                 terminations=episode["terminations"],
                 truncations=episode["truncations"],
-                infos=episode.get("infos"),
+                infos=episode.get("infos",[]),
             )
             self.update_episodes([episode_buffer])
 

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -149,7 +149,6 @@ class MinariStorage(ABC):
 
         infos_format = infos_format or "dict"
 
-
         data_path = pathlib.Path(data_path)
         data_path.mkdir(exist_ok=True)
         if data_path.joinpath(METADATA_FILE_NAME).exists():

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -114,6 +114,7 @@ class MinariStorage(ABC):
         action_space: Optional[gym.Space] = None,
         env_spec: Optional[EnvSpec] = None,
         data_format: str = "hdf5",
+        infos_format: Optional[str] = None,
     ) -> MinariStorage:
         """Class method to create a new data storage.
 
@@ -123,6 +124,7 @@ class MinariStorage(ABC):
             action_space (gymnasium.Space, optional): Gymnasium action space of the dataset.
             env_spec (EnvSpec, optional): Gymnasium EnvSpec of the environment that generates the dataset.
             data_format (str): Format of the data. Default value is "hdf5".
+            infos_format (str): Format of the infos data. Can be "dict" or "list". Default value is "dict".
 
         Returns:
             A new MinariStorage object to write new data.
@@ -145,6 +147,9 @@ class MinariStorage(ABC):
                 f"No storage implemented for {data_format}. Available formats: {get_storage_keys()}"
             )
 
+        infos_format = infos_format or "dict"
+
+
         data_path = pathlib.Path(data_path)
         data_path.mkdir(exist_ok=True)
         if data_path.joinpath(METADATA_FILE_NAME).exists():
@@ -164,6 +169,7 @@ class MinariStorage(ABC):
             "total_episodes": 0,
             "total_steps": 0,
             "data_format": data_format,
+            "infos_format": infos_format,
             "observation_space": serialize_space(observation_space),
             "action_space": serialize_space(action_space),
         }
@@ -217,6 +223,7 @@ class MinariStorage(ABC):
             "action_space",
             "env_spec",
             "data_format",
+            "infos_format",
             "minari_version",
         }
 
@@ -326,7 +333,7 @@ class MinariStorage(ABC):
                 rewards=episode["rewards"],
                 terminations=episode["terminations"],
                 truncations=episode["truncations"],
-                infos=episode.get("infos", []),
+                infos=episode.get("infos"),
             )
             self.update_episodes([episode_buffer])
 

--- a/minari/dataset/minari_storage.py
+++ b/minari/dataset/minari_storage.py
@@ -14,7 +14,6 @@ from gymnasium.envs.registration import EnvSpec
 from minari.data_collector.episode_buffer import EpisodeBuffer
 from minari.serialization import deserialize_space, serialize_space
 
-
 PathLike = Union[str, os.PathLike]
 METADATA_FILE_NAME = "metadata.json"
 

--- a/minari/utils.py
+++ b/minari/utils.py
@@ -346,6 +346,7 @@ def create_dataset_from_buffers(
     num_episodes_average_score: int = 100,
     description: Optional[str] = None,
     data_format: Optional[str] = None,
+    infos_format: Optional[str] = None,
     requirements: Optional[list] = None,
 ):
     """Create Minari dataset from a list of episode dictionary buffers.
@@ -375,6 +376,7 @@ def create_dataset_from_buffers(
         observation_space (gym.spaces.Space, optional): observation space of the environment. If None (default) use the environment observation space.
         description (str, optional): description of the dataset being created. Defaults to None.
         data_format (str, optional): Data format to store the data in the Minari dataset. If None (defaults), it will use the default format of MinariStorage.
+        infos_format (str, optional): Format of the infos data. Can be "dict" or "list". Defaults to None.
         requirements (list of str, optional): list of requirements in pip-style to load the environment and reproduce the dataset. For example, `mujoco>=3.1.0,<3.2.0`, which indicate the supported version range for mujoco package. Defaults to None.
 
     Returns:
@@ -424,6 +426,7 @@ def create_dataset_from_buffers(
         observation_space=observation_space,
         action_space=action_space,
         env_spec=env_spec,
+        infos_format=infos_format,
         **data_format_kwarg,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,9 @@ arrow = ["pyarrow"]
 hdf5 = ["h5py>=3.8.0"]
 gcs = ["google-cloud-storage>=2.5.0", "tqdm>=4.65.0"]
 create = ["jax[cpu]"]
+orjson = ["orjson>=3.10.0"]
 
-all = ["minari[arrow,hdf5,gcs,create]"]
+all = ["minari[arrow,hdf5,gcs,create,orjson]"]
 
 testing = [
     "pytest>=7.1.3",

--- a/tests/common.py
+++ b/tests/common.py
@@ -632,9 +632,8 @@ def check_episode_data_integrity(
             obs = _reconstuct_obs_or_action_at_index_recursive(episode.observations, i)
             if info_sample is not None:
                 assert episode.infos is not None
-                assert check_infos_equal(
-                    get_info_at_step_index(episode.infos, i), info_sample
-                )
+                info = get_info_at_step_index(episode.infos, i)
+                assert check_infos_equal(info, info_sample)
 
             assert observation_space.contains(obs)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -608,7 +608,7 @@ def check_episode_data_integrity(
     episode_data_list: Union[List[EpisodeData], MinariDataset],
     observation_space: gym.spaces.Space,
     action_space: gym.spaces.Space,
-    info_sample: Optional[dict] = None,
+    info_sample: Optional[Union[dict, List[Dict]]] = None,
 ):
     """Checks to see if a list of EpisodeData instances has consistent data and that the observations and actions are in the appropriate spaces.
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -493,7 +493,7 @@ def check_data_integrity(dataset: MinariDataset, episode_indices: List[int]):
     assert total_steps == dataset.total_steps
 
 
-def get_info_at_step_index(infos: Dict|List[Dict], step_index: int) -> Dict:
+def get_info_at_step_index(infos: Union[Dict, List[Dict]], step_index: int) -> Dict:
 
     if isinstance(infos, dict):  # for backwards compatibility
         result = {}
@@ -608,7 +608,7 @@ def check_episode_data_integrity(
     episode_data_list: Union[List[EpisodeData], MinariDataset],
     observation_space: gym.spaces.Space,
     action_space: gym.spaces.Space,
-    info_sample: Optional[Union[dict, List[Dict]]] = None,
+    info_sample: Optional[Union[Dict, List[Dict]]] = None,
 ):
     """Checks to see if a list of EpisodeData instances has consistent data and that the observations and actions are in the appropriate spaces.
 
@@ -616,7 +616,7 @@ def check_episode_data_integrity(
         episode_data_list (List[EpisodeData]): A list of EpisodeData instances representing episodes.
         observation_space (gym.spaces.Space): The environment's observation space.
         action_space (gym.spaces.Space): The environment's action space.
-        info_sample (dict|list(dict)): An info returned by the environment used to build the dataset.
+        info_sample (Optional[Union[Dict, List[Dict]]]): An info returned by the environment used to build the dataset.
 
     """
     # verify the actions and observations are in the appropriate action space and observation space, and that the episode lengths are correct
@@ -647,7 +647,7 @@ def check_episode_data_integrity(
         assert len(episode) == len(episode.truncations)
 
 
-def check_infos_equal(info_1: Dict, info_2: Dict) -> bool:
+def check_infos_equal(info_1: Dict, info_2: Union[Dict, List[Dict]]) -> bool:
     if info_1.keys() != info_2.keys():
         return False
     for key in info_1.keys():

--- a/tests/common.py
+++ b/tests/common.py
@@ -616,7 +616,7 @@ def check_episode_data_integrity(
         episode_data_list (List[EpisodeData]): A list of EpisodeData instances representing episodes.
         observation_space (gym.spaces.Space): The environment's observation space.
         action_space (gym.spaces.Space): The environment's action space.
-        info_sample (dict): An info returned by the environment used to build the dataset.
+        info_sample (dict|list(dict)): An info returned by the environment used to build the dataset.
 
     """
     # verify the actions and observations are in the appropriate action space and observation space, and that the episode lengths are correct
@@ -656,7 +656,7 @@ def check_infos_equal(info_1: Dict, info_2: Dict) -> bool:
         elif isinstance(info_1[key], np.ndarray):
             return bool(np.all(info_1[key] == info_2[key]))
         else:
-            return info_1[key] == info_2[key]
+            return bool(np.all(info_1[key] == info_2[key]))
     return True
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -495,7 +495,9 @@ def check_data_integrity(dataset: MinariDataset, episode_indices: List[int]):
 
 def get_info_at_step_index(infos: Union[Dict, List[Dict]], step_index: int) -> Dict:
 
-    if isinstance(infos, dict):  # for backwards compatibility
+    if infos is None:
+        return {}
+    elif isinstance(infos, dict):  # for backwards compatibility
         result = {}
         for key in infos.keys():
             if isinstance(infos[key], dict):
@@ -511,6 +513,7 @@ def get_info_at_step_index(infos: Union[Dict, List[Dict]], step_index: int) -> D
         return infos[step_index]
 
     else:
+        print(infos, type(infos))
         raise ValueError(
             "Infos are in an unsupported format; see Minari documentation for supported formats."
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -608,7 +608,7 @@ def check_episode_data_integrity(
     episode_data_list: Union[List[EpisodeData], MinariDataset],
     observation_space: gym.spaces.Space,
     action_space: gym.spaces.Space,
-    info_sample: Optional[Union[Dict, List[Dict]]] = None,
+    info_sample: Optional[Dict] = None,
 ):
     """Checks to see if a list of EpisodeData instances has consistent data and that the observations and actions are in the appropriate spaces.
 
@@ -647,7 +647,7 @@ def check_episode_data_integrity(
         assert len(episode) == len(episode.truncations)
 
 
-def check_infos_equal(info_1: Dict, info_2: Union[Dict, List[Dict]]) -> bool:
+def check_infos_equal(info_1: Dict, info_2: Dict) -> bool:
     if info_1.keys() != info_2.keys():
         return False
     for key in info_1.keys():

--- a/tests/common.py
+++ b/tests/common.py
@@ -493,18 +493,27 @@ def check_data_integrity(dataset: MinariDataset, episode_indices: List[int]):
     assert total_steps == dataset.total_steps
 
 
-def get_info_at_step_index(infos: Dict, step_index: int) -> Dict:
-    result = {}
-    for key in infos.keys():
-        if isinstance(infos[key], dict):
-            result[key] = get_info_at_step_index(infos[key], step_index)
-        elif isinstance(infos[key], np.ndarray):
-            result[key] = infos[key][step_index]
-        else:
-            raise ValueError(
-                "Infos are in an unsupported format; see Minari documentation for supported formats."
-            )
-    return result
+def get_info_at_step_index(infos: Dict|List[Dict], step_index: int) -> Dict:
+
+    if isinstance(infos, dict):  # for backwards compatibility
+        result = {}
+        for key in infos.keys():
+            if isinstance(infos[key], dict):
+                result[key] = get_info_at_step_index(infos[key], step_index)
+            elif isinstance(infos[key], np.ndarray):
+                result[key] = infos[key][step_index]
+            else:
+                raise ValueError(
+                    "Infos are in an unsupported format; see Minari documentation for supported formats."
+                )
+        return result
+    elif isinstance(infos, list):
+        return infos[step_index]
+
+    else:
+        raise ValueError(
+            "Infos are in an unsupported format; see Minari documentation for supported formats."
+        )
 
 
 def _reconstuct_obs_or_action_at_index_recursive(

--- a/tests/data_collector/callbacks/test_step_data_callback.py
+++ b/tests/data_collector/callbacks/test_step_data_callback.py
@@ -111,8 +111,9 @@ def test_data_collector_step_data_callback(data_format, register_dummy_envs):
 
 
 @pytest.mark.parametrize("data_format", get_storage_keys())
+@pytest.mark.parametrize("infos_format", ["dict", "list"])
 def test_data_collector_step_data_callback_info_correction(
-    data_format, register_dummy_envs
+    data_format, register_dummy_envs, infos_format
 ):
     """Test DataCollector wrapper and Minari dataset creation."""
     dataset_id = "dummy-inconsistent-info-v0"
@@ -123,6 +124,7 @@ def test_data_collector_step_data_callback_info_correction(
         record_infos=True,
         step_data_callback=CustomSubsetInfoPadStepDataCallback,
         data_format=data_format,
+        infos_format=infos_format,
     )
     num_episodes = 10
 
@@ -164,7 +166,8 @@ def test_data_collector_step_data_callback_info_correction(
         record_infos=True,
     )
     # here we are checking to make sure that if we have an environment changing its info
-    # structure across steps, IT IS OK!
+    # structure across steps, it results in an error when infos_format is the default (dict)
+    # behaviour.
     with pytest.raises(ValueError):
         num_episodes = 10
         env.reset(seed=42)
@@ -176,5 +179,8 @@ def test_data_collector_step_data_callback_info_correction(
                 _, _, terminated, truncated, _ = env.step(action)
 
             env.reset()
-        raise ValueError("This should BE reached")
+        if infos_format == "list":
+            raise ValueError(
+                "This should be raised to indicate the test succeeded for infos_format='list'"
+            )
     env.close()

--- a/tests/data_collector/callbacks/test_step_data_callback.py
+++ b/tests/data_collector/callbacks/test_step_data_callback.py
@@ -164,7 +164,7 @@ def test_data_collector_step_data_callback_info_correction(
         record_infos=True,
     )
     # here we are checking to make sure that if we have an environment changing its info
-    # structure across steps, it is results in a error
+    # structure across steps, IT IS OK!
     with pytest.raises(ValueError):
         num_episodes = 10
         env.reset(seed=42)
@@ -176,4 +176,5 @@ def test_data_collector_step_data_callback_info_correction(
                 _, _, terminated, truncated, _ = env.step(action)
 
             env.reset()
+        raise ValueError("This should BE reached")
     env.close()

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -142,7 +142,12 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
         else:
             assert np.array_equal(first_step.observations, last_step.observations)
 
-        check_infos_equal(last_step.infos, first_step.infos)
+        if isinstance(last_step.infos, dict) and isinstance(first_step.infos, dict):
+            check_infos_equal(last_step.infos, first_step.infos)
+        else:
+            assert last_step.infos == first_step.infos
+            check_infos_equal(last_step.infos[0], first_step.infos[0])
+            
         last_step = get_single_step_from_episode(episode, -1)
         assert bool(last_step.truncations) is True
 

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -13,7 +13,6 @@ from tests.common import (
     get_info_at_step_index,
 )
 
-
 MAX_UINT64 = np.iinfo(np.uint64).max
 
 
@@ -136,7 +135,7 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
         # Check that the last observation of the previous episode is carried over to the next episode
         # as the reset observation.
         if isinstance(first_step.observations, dict) or isinstance(
-            first_step.observations, tuple
+                first_step.observations, tuple
         ):
             assert first_step.observations == last_step.observations
         else:
@@ -147,7 +146,7 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
         else:
             assert last_step.infos == first_step.infos
             check_infos_equal(last_step.infos[0], first_step.infos[0])
-            
+
         last_step = get_single_step_from_episode(episode, -1)
         assert bool(last_step.truncations) is True
 

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -13,6 +13,7 @@ from tests.common import (
     get_info_at_step_index,
 )
 
+
 MAX_UINT64 = np.iinfo(np.uint64).max
 
 
@@ -135,7 +136,7 @@ def test_truncation_without_reset(dataset_id, env_id, data_format, register_dumm
         # Check that the last observation of the previous episode is carried over to the next episode
         # as the reset observation.
         if isinstance(first_step.observations, dict) or isinstance(
-                first_step.observations, tuple
+            first_step.observations, tuple
         ):
             assert first_step.observations == last_step.observations
         else:

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -41,7 +41,7 @@ def test_episode_data(space: gym.Space):
         rewards=rewards,
         terminations=terminations,
         truncations=truncations,
-        infos={"info": True},
+        infos=[{"info": True}],
     )
 
     pattern = r"EpisodeData\("

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -59,9 +59,9 @@ def test_non_existing_data(tmp_dataset_dir):
     with pytest.raises(ValueError, match="No data found in data path"):
         MinariStorage.read(tmp_dataset_dir)
 
-
+@pytest.mark.parametrize("infos_format", ["dict", "list"])
 @pytest.mark.parametrize("data_format", get_storage_keys())
-def test_metadata(tmp_dataset_dir, data_format):
+def test_metadata(tmp_dataset_dir, data_format, infos_format):
     action_space = spaces.Box(-1, 1)
     observation_space = spaces.Box(-1, 1)
     storage = MinariStorage.new(
@@ -69,6 +69,7 @@ def test_metadata(tmp_dataset_dir, data_format):
         observation_space=observation_space,
         action_space=action_space,
         data_format=data_format,
+        infos_format=infos_format,
     )
     assert str(storage.data_path) == tmp_dataset_dir
 
@@ -86,6 +87,7 @@ def test_metadata(tmp_dataset_dir, data_format):
         "total_episodes",
         "total_steps",
         "data_format",
+        "infos_format",
     }
 
     for key, value in extra_metadata.items():
@@ -94,9 +96,9 @@ def test_metadata(tmp_dataset_dir, data_format):
     storage2 = MinariStorage.read(tmp_dataset_dir)
     assert storage_metadata == storage2.metadata
 
-
+@pytest.mark.parametrize("infos_format", ["dict", "list"])
 @pytest.mark.parametrize("data_format", get_storage_keys())
-def test_add_episodes(tmp_dataset_dir, data_format):
+def test_add_episodes(tmp_dataset_dir, data_format,infos_format):
     action_space = spaces.Box(-1, 1, shape=(10,))
     observation_space = spaces.Text(max_length=5)
     n_episodes = 10
@@ -112,6 +114,7 @@ def test_add_episodes(tmp_dataset_dir, data_format):
         observation_space=observation_space,
         action_space=action_space,
         data_format=data_format,
+        infos_format=infos_format,
     )
     storage.update_episodes(episodes)
     del storage

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -59,6 +59,7 @@ def test_non_existing_data(tmp_dataset_dir):
     with pytest.raises(ValueError, match="No data found in data path"):
         MinariStorage.read(tmp_dataset_dir)
 
+
 @pytest.mark.parametrize("infos_format", ["dict", "list"])
 @pytest.mark.parametrize("data_format", get_storage_keys())
 def test_metadata(tmp_dataset_dir, data_format, infos_format):
@@ -96,9 +97,10 @@ def test_metadata(tmp_dataset_dir, data_format, infos_format):
     storage2 = MinariStorage.read(tmp_dataset_dir)
     assert storage_metadata == storage2.metadata
 
+
 @pytest.mark.parametrize("infos_format", ["dict", "list"])
 @pytest.mark.parametrize("data_format", get_storage_keys())
-def test_add_episodes(tmp_dataset_dir, data_format,infos_format):
+def test_add_episodes(tmp_dataset_dir, data_format, infos_format):
     action_space = spaces.Box(-1, 1, shape=(10,))
     observation_space = spaces.Text(max_length=5)
     n_episodes = 10

--- a/tests/utils/test_dataset_combine.py
+++ b/tests/utils/test_dataset_combine.py
@@ -62,17 +62,18 @@ def test_combine_datasets():
     # generating multiple test datasets
     test_max_episode_steps = [5, 3, 7, 10, None]
     data_formats = ["hdf5", "arrow", None, "arrow", None]
+    infos_formats = ["dict", None, "list", "list", None]
 
     test_datasets = []
-    for dataset_id, max_episode_steps, data_format in zip(
-        test_datasets_ids, test_max_episode_steps, data_formats
+    for dataset_id, max_episode_steps, data_format, infos_formats in zip(
+        test_datasets_ids, test_max_episode_steps, data_formats, infos_formats
     ):
         env = gym.make("CartPole-v1", max_episode_steps=max_episode_steps)
         assert env.spec is not None
         env.spec.max_episode_steps = (
             max_episode_steps  # with None max_episode_steps=default
         )
-        env = DataCollector(env, data_format=data_format)
+        env = DataCollector(env, data_format=data_format, infos_format=infos_formats)
         dataset = create_dummy_dataset_with_collecter_env_helper(
             dataset_id, env, num_episodes
         )

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -31,7 +31,9 @@ CODELINK = "https://github.com/Farama-Foundation/Minari/blob/main/tests/utils/te
     cartpole_test_dataset + dummy_test_datasets + dummy_text_dataset,
 )
 @pytest.mark.parametrize("infos_format", ["dict", "list"])
-def test_generate_dataset_with_collector_env(dataset_id, env_id, register_dummy_envs, infos_format):
+def test_generate_dataset_with_collector_env(
+    dataset_id, env_id, register_dummy_envs, infos_format
+):
     """Test DataCollector wrapper and Minari dataset creation."""
     env = gym.make(env_id)
     env = DataCollector(env, record_infos=True, infos_format=infos_format)
@@ -92,17 +94,21 @@ def test_generate_dataset_with_collector_env(dataset_id, env_id, register_dummy_
     [
         None,
         {},
-        {"foo": np.ones((10, 10), dtype=np.float32)}, # TODO: causes non-serializable warning
+        {
+            "foo": np.ones((10, 10), dtype=np.float32)
+        },  # TODO: causes non-serializable warning
         {"int": 1},
         {"bool": False},
         {
             "value1": True,
             "value2": 5,
-            "value3": {"nested1": False, "nested2": np.empty(10)}, # TODO: causes non-serializable warning
+            "value3": {
+                "nested1": False,
+                "nested2": np.empty(10),
+            },  # TODO: causes non-serializable warning
         },
     ],
 )
-
 @pytest.mark.parametrize("infos_format", ["dict", "list"])
 def test_record_infos_collector_env(info_override, register_dummy_envs, infos_format):
     """Test DataCollector wrapper and Minari dataset creation including infos."""
@@ -387,7 +393,7 @@ def test_generate_big_episode(data_format, register_dummy_envs, infos_format):
     assert np.all(dataset[0].truncations == buffer.truncations)
     buffer_infos = buffer.infos
     assert buffer_infos is not None
-    print(infos_format,type(dataset[0].infos) )
+    print(infos_format, type(dataset[0].infos))
     if infos_format == "dict":
         assert np.all(dataset[0].infos["info1"] == buffer_infos["info1"])
         assert np.all(dataset[0].infos["info2"] == buffer_infos["info2"])

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -346,7 +346,7 @@ def test_generate_big_episode(data_format, register_dummy_envs):
     )
 
     buffer = EpisodeBuffer(
-        observations=[observation_space.sample()], infos=info_generator.sample()
+        observations=[observation_space.sample()], infos=[info_generator.sample()]
     )
     for step_id in range(episode_length):
         buffer = buffer.add_step_data(
@@ -380,5 +380,7 @@ def test_generate_big_episode(data_format, register_dummy_envs):
     assert np.all(dataset[0].truncations == buffer.truncations)
     buffer_infos = buffer.infos
     assert buffer_infos is not None
-    assert np.all(dataset[0].infos["info1"] == buffer_infos["info1"])
-    assert np.all(dataset[0].infos["info2"] == buffer_infos["info2"])
+    assert len(dataset[0].infos) == len(buffer_infos)
+    for ds_info, buf_info in zip(dataset[0].infos, buffer_infos):
+        assert np.all(np.array(ds_info["info1"]) == np.array(buf_info["info1"]))
+        assert np.all(np.array(ds_info["info2"]) == np.array(buf_info["info2"]))

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -393,12 +393,15 @@ def test_generate_big_episode(data_format, register_dummy_envs, infos_format):
     assert np.all(dataset[0].truncations == buffer.truncations)
     buffer_infos = buffer.infos
     assert buffer_infos is not None
-    print(infos_format, type(dataset[0].infos))
     if infos_format == "dict":
+        assert isinstance(dataset[0].infos, dict)
+        assert isinstance(buffer_infos, dict)
         assert np.all(dataset[0].infos["info1"] == buffer_infos["info1"])
         assert np.all(dataset[0].infos["info2"] == buffer_infos["info2"])
     else:
         assert len(dataset[0].infos) == len(buffer_infos)
+        assert isinstance(dataset[0].infos, list)
+        assert isinstance(buffer_infos, list)
         for ds_info, buf_info in zip(dataset[0].infos, buffer_infos):
             assert np.all(np.array(ds_info["info1"]) == np.array(buf_info["info1"]))
             assert np.all(np.array(ds_info["info2"]) == np.array(buf_info["info2"]))


### PR DESCRIPTION
Infos is now a List[Dict]

# Description

Allow for infos to be a list of heterogeneous dicts. Currently many environments use different keys for reset() and step(). Also wrappers are free to add arbitrary keys at arbitrary steps, for instance, RecordEspisodeStatistics add keys in the final step.

Hence, so save infos the users has to use almost always a custom step callback to regularize info data. 

Fixes #246 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update (perhaps)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have run `pytest -v` and no errors are present. 
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Backwards compatibility checks.
- [X] New feature tests for backends: hdf5 and arrow.
- [X] New parameter `infos_format= None|"dict", "list"` to add the optional functionality
- [X] New parameter `infos_format= None|"dict", "list"` to add the optional functionality

