### PR TITLE
ENH: Allow complete remote path for list, download and show

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ tutorials/**/index
 :hidden:
 :caption: Datasets
 datasets/D4RL/index
+datasets/minigrid/index
 datasets/mujoco/index
 ```
 

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -80,15 +80,15 @@ def list_local_datasets(
         parent_dir = base_path.joinpath(namespace)
         if not parent_dir.exists():
             return
+        # TODO: metadata.json of HDF5 should stay in dataset root directory not /data
+        # Then we can use metadata.json to check if it is a dataset
+        if parent_dir.joinpath("data").exists():
+            dataset_ids.append(namespace)
+            return
 
         for dir_name in list_non_hidden_dirs(parent_dir):
-            dir_path = os.path.join(parent_dir, dir_name)
             namespaced_dir_name = os.path.join(namespace, dir_name)
-            # Minari datasets must contain the data directory.
-            if "data" in os.listdir(dir_path):
-                dataset_ids.append(pathlib.PurePath(namespaced_dir_name).as_posix())
-            else:
-                recurse_directories(base_path, namespaced_dir_name)
+            recurse_directories(base_path, namespaced_dir_name)
 
     recurse_directories(datasets_path, prefix or "")
 

--- a/minari/storage/remotes/__init__.py
+++ b/minari/storage/remotes/__init__.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Dict, Type
+from typing import Callable, Dict, Optional, Type
 
 from minari.storage.remotes.cloud_storage import CloudStorage
 
@@ -25,7 +25,10 @@ _registry: Dict[str, Callable[[], Type[CloudStorage]]] = {
 }
 
 
-def get_cloud_storage(token=None) -> CloudStorage:
-    remote_spec = os.getenv("MINARI_REMOTE", DEFAULT_REMOTE)
-    cloud_type, name = remote_spec.split("://", maxsplit=1)
+def get_cloud_storage(
+    remote_path: Optional[str] = None, token: Optional[str] = None
+) -> CloudStorage:
+    if remote_path is None:
+        remote_path = os.getenv("MINARI_REMOTE", DEFAULT_REMOTE)
+    cloud_type, name = remote_path.split("://", maxsplit=1)
     return _registry[cloud_type]()(name, token)

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,7 +13,6 @@ import minari
 from minari import DataCollector, EpisodeData, MinariDataset, StepData
 from minari.data_collector import EpisodeBuffer
 from minari.dataset.minari_dataset import gen_dataset_id
-from minari.storage.hosting import get_remote_dataset_versions
 
 
 unicode_charset = "".join(
@@ -690,9 +689,8 @@ def get_sample_buffer_for_dataset_from_env(env: gym.Env, num_episodes: int = 10)
 
 
 def get_latest_compatible_dataset_id(namespace, dataset_name):
-    latest_compatible_versions = get_remote_dataset_versions(
-        namespace=namespace,
-        dataset_name=dataset_name,
+    latest_compatible_versions = minari.list_remote_datasets(
+        prefix=gen_dataset_id(namespace, dataset_name),
         latest_version=True,
         compatible_minari_version=True,
     )
@@ -703,7 +701,7 @@ def get_latest_compatible_dataset_id(namespace, dataset_name):
         )
 
     assert len(latest_compatible_versions) == 1
-    return gen_dataset_id(namespace, dataset_name, latest_compatible_versions[0])
+    return next(iter(latest_compatible_versions))
 
 
 def skip_if_error(error_type):


### PR DESCRIPTION
Allow CLI commands like
`minari download hf://farama-minari/D4RL/door/human-v2`
`minari list hf://farama-minari/D4RL`
`minari show hf://farama-minari/D4RL/door/human-v2`

Similarly, in `minari.list_remote_datasets` it is now possible to specify `remote_path` and `prefix`. The latter is avaiable also for listing local datasets.