### PR TITLE
uniform terminated/truncated naming

### DIFF
--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -117,7 +117,7 @@ def main():
 
             versioned_name = gen_dataset_id(None, dataset_name, version)
             NAMESPACE_CONTENTS[namespace][dataset_id] = {
-                "short_description": metadata.get("description", "").split(". ", 1)[0],
+                "short_description": metadata.get("description", "").split(".", 1)[0],
                 "file": versioned_name,
                 "toctree": versioned_name,
                 "display_name": versioned_name,

--- a/minari/data_collector/callbacks/step_callback.py
+++ b/minari/data_collector/callbacks/step_callback.py
@@ -61,8 +61,8 @@ class StepDataCallback:
             "action": action,
             "observation": obs,
             "reward": rew,
-            "termination": terminated,
-            "truncation": truncated,
+            "terminated": terminated,
+            "truncated": truncated,
             "info": info,
         }
 

--- a/minari/data_collector/data_collector.py
+++ b/minari/data_collector/data_collector.py
@@ -154,7 +154,7 @@ class DataCollector(gym.Wrapper):
             step_data["info"] = {}
         self._buffer = self._buffer.add_step_data(step_data)
 
-        if step_data["termination"] or step_data["truncation"]:
+        if step_data["terminated"] or step_data["truncated"]:
             self._storage.update_episodes([self._buffer])
             self._episode_id += 1
             self._buffer = EpisodeBuffer(

--- a/minari/data_collector/episode_buffer.py
+++ b/minari/data_collector/episode_buffer.py
@@ -60,8 +60,8 @@ class EpisodeBuffer:
             infos = jtu.tree_map(_append, step_data["info"], self.infos)
 
         self.rewards.append(step_data["reward"])
-        self.terminations.append(step_data["termination"])
-        self.truncations.append(step_data["truncation"])
+        self.terminations.append(step_data["terminated"])
+        self.truncations.append(step_data["truncated"])
 
         return EpisodeBuffer(
             id=self.id,

--- a/minari/dataset/step_data.py
+++ b/minari/dataset/step_data.py
@@ -7,6 +7,6 @@ class StepData(TypedDict):
     observation: Any
     action: Optional[Any]
     reward: Optional[SupportsFloat]
-    termination: Optional[bool]
-    truncation: Optional[bool]
+    terminated: Optional[bool]
+    truncated: Optional[bool]
     info: Dict[str, Any]

--- a/tests/common.py
+++ b/tests/common.py
@@ -674,8 +674,8 @@ def get_sample_buffer_for_dataset_from_env(env: gym.Env, num_episodes: int = 10)
                 "observation": observation,
                 "action": action,
                 "reward": reward,
-                "termination": terminated,
-                "truncation": truncated,
+                "terminated": terminated,
+                "truncated": truncated,
                 "info": {},
             }
             episode_buffer = episode_buffer.add_step_data(step_data)

--- a/tests/data_collector/test_data_collector.py
+++ b/tests/data_collector/test_data_collector.py
@@ -27,9 +27,9 @@ class ForceTruncateStepDataCallback(StepDataCallback):
     def __call__(self, env, **kwargs):
         step_data = super().__call__(env, **kwargs)
         if self.time_steps != 0:
-            step_data["termination"] = False
+            step_data["terminated"] = False
             if self.time_steps % self.episode_steps == 0:
-                step_data["truncation"] = True
+                step_data["truncated"] = True
 
         self.time_steps += 1
         return step_data

--- a/tests/dataset/test_minari_dataset.py
+++ b/tests/dataset/test_minari_dataset.py
@@ -196,8 +196,8 @@ def test_filter_episodes_and_subsequent_updates(
                 "observation": observation,
                 "action": action,
                 "reward": reward,
-                "termination": terminated,
-                "truncation": truncated,
+                "terminated": terminated,
+                "truncated": truncated,
                 "info": {},
             }
             episode_buffer = episode_buffer.add_step_data(step_data)
@@ -357,8 +357,8 @@ def test_update_dataset_from_buffer(
                 "observation": observation,
                 "action": action,
                 "reward": reward,
-                "termination": terminated,
-                "truncation": truncated,
+                "terminated": terminated,
+                "truncated": truncated,
                 "info": {},
             }
             episode_buffer = episode_buffer.add_step_data(step_data)

--- a/tests/dataset/test_minari_storage.py
+++ b/tests/dataset/test_minari_storage.py
@@ -43,8 +43,8 @@ def _generate_episode_buffer(
             "observation": observation,
             "action": action,
             "reward": rewards[i],
-            "termination": terminations[i],
-            "truncation": truncations[i],
+            "terminated": terminations[i],
+            "truncated": truncations[i],
             "info": {},
         }
         buffer = buffer.add_step_data(step_data)
@@ -267,8 +267,8 @@ def test_minari_get_dataset_size_from_buffer(
                 "observation": observation,
                 "action": action,
                 "reward": reward,
-                "termination": terminated,
-                "truncation": truncated,
+                "terminated": terminated,
+                "truncated": truncated,
                 "info": {},
             }
             episode_buffer = episode_buffer.add_step_data(step_data)

--- a/tests/utils/test_dataset_creation.py
+++ b/tests/utils/test_dataset_creation.py
@@ -182,8 +182,8 @@ def test_generate_dataset_with_external_buffer(
                 "observation": observation,
                 "action": action,
                 "reward": reward,
-                "termination": terminated,
-                "truncation": truncated,
+                "terminated": terminated,
+                "truncated": truncated,
                 "info": {},
             }
             episode_buffer = episode_buffer.add_step_data(step_data)
@@ -354,8 +354,8 @@ def test_generate_big_episode(data_format, register_dummy_envs):
                 "observation": observation_space.sample(),
                 "action": action_space.sample(),
                 "reward": 0.0,
-                "termination": False,
-                "truncation": step_id == episode_length - 1,
+                "terminated": False,
+                "truncated": step_id == episode_length - 1,
                 "info": info_generator.sample(),
             }
         )


### PR DESCRIPTION
Use always terminated/truncated when singular (in StepData).