### PR TITLE
Fix incorrect path name on windows

### DIFF
--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -36,7 +36,6 @@ def parse_dataset_id(dataset_id: str) -> tuple[str | None, str, int]:
     Raises:
         Error: If the dataset id is not valid dataset regex
     """
-    dataset_id = dataset_id.replace("\\", "/")
     match = DATASET_ID_RE.fullmatch(dataset_id)
     if not match:
         raise ValueError(

--- a/minari/dataset/minari_dataset.py
+++ b/minari/dataset/minari_dataset.py
@@ -36,6 +36,7 @@ def parse_dataset_id(dataset_id: str) -> tuple[str | None, str, int]:
     Raises:
         Error: If the dataset id is not valid dataset regex
     """
+    dataset_id = dataset_id.replace("\\", "/")
     match = DATASET_ID_RE.fullmatch(dataset_id)
     if not match:
         raise ValueError(

--- a/minari/storage/local.py
+++ b/minari/storage/local.py
@@ -87,7 +87,7 @@ def list_local_datasets(
             return
 
         for dir_name in list_non_hidden_dirs(parent_dir):
-            namespaced_dir_name = os.path.join(namespace, dir_name)
+            namespaced_dir_name = pathlib.Path(namespace, dir_name).as_posix()
             recurse_directories(base_path, namespaced_dir_name)
 
     recurse_directories(datasets_path, prefix or "")
@@ -96,7 +96,7 @@ def list_local_datasets(
 
     local_datasets = {}
     for dst_id in dataset_ids:
-        data_path = os.path.join(datasets_path, dst_id, "data")
+        data_path = pathlib.Path(datasets_path, dst_id, "data").as_posix()
         try:
             metadata = MinariStorage.read_raw_metadata(data_path)
             metadata_id = metadata["dataset_id"]

--- a/minari/storage/remotes/huggingface.py
+++ b/minari/storage/remotes/huggingface.py
@@ -151,7 +151,7 @@ class HuggingFaceStorage(CloudStorage):
         repo_id, path_in_repo = self._decompose_path(dataset_id)
         dataset_metadata = self._api.hf_hub_download(
             repo_id=f"{self.name}/{repo_id}",
-            filename=os.path.join(path_in_repo, "data", METADATA_FILE_NAME),
+            filename=Path(path_in_repo, "data", METADATA_FILE_NAME).as_posix(),
             repo_type="dataset",
         )
         with open(dataset_metadata) as f:
@@ -179,7 +179,7 @@ class HuggingFaceStorage(CloudStorage):
         repo_id, path_in_repo = self._decompose_path(namespace)
         self._api.hf_hub_download(
             repo_id=f"{self.name}/{repo_id}",
-            filename=os.path.join(path_in_repo, _NAMESPACE_METADATA_FILENAME),
+            filename=Path(path_in_repo, _NAMESPACE_METADATA_FILENAME).as_posix(),
             repo_type="dataset",
             local_dir=path.joinpath(repo_id),
             force_download=True,


### PR DESCRIPTION
# Description

Fix bug where, on Windows, the dataset URL is constructed using a file path generated by os.path.join. This function produces Windows-style paths with backslashes (\), which—when used in a URL—get URL-encoded (e.g., %5C) and result in an "Entry Not Found" error on Hugging Face. Additionally, when parsing the dataset_id from local dataset (local_dsts = local.list_local_datasets() ), the Windows path produces a double slash (\\), leading to an invalid dataset id.

Fixes #277

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
