### PR TITLE
Fixed wrong typer version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.21.0",
     "typing_extensions>=4.4.0",
-    "typer[all]>=0.9.0",
+    "typer>=0.9.0",
     "gymnasium>=0.28.1",
     "packaging",
 ]


### PR DESCRIPTION
# Description

Miniscule change that prevents the warning
warning: The package typer==0.16.0 does not have an extra named all