### PR TITLE
fix: Fix doc for atari

### DIFF
--- a/docs/_scripts/gen_dataset_md.py
+++ b/docs/_scripts/gen_dataset_md.py
@@ -96,8 +96,10 @@ def main():
     os.environ["TQDM_DISABLE"] = "1"
 
     def short_desc(desc: str) -> str:
-        match = re.search(r'\.(?!\s*(?:Mr|Mrs|Dr|Ms|Prof|Sr|Jr)\b)(?:\s*[A-Z]|\n)', desc)
-        return (desc[:match.start() + 1] if match else desc).split("\n", 1)[0]
+        match = re.search(
+            r"\.(?!\s*(?:Mr|Mrs|Dr|Ms|Prof|Sr|Jr)\b)(?:\s*[A-Z]|\n)", desc
+        )
+        return (desc[: match.start() + 1] if match else desc).split("\n", 1)[0]
 
     remote_datasets = minari.list_remote_datasets(latest_version=True)
     for i, (dataset_id, metadata) in enumerate(remote_datasets.items()):


### PR DESCRIPTION
# Description

  This PR fixes an issue where simple string splitting logic failed to properly extract short descriptions for Atari game
  datasets.

  Changes:
  - Added a short_desc() helper function using regex to intelligently extract the first sentence from descriptions, correctly
  handling abbreviations (Mr., Dr., etc.) and avoiding false positives
  - Added sorting for namespace content by display_name
  - Fixed missing metadata download for top-level namespaces

Fixes #315 (issue), Depends on #317 (pull request)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
