### PR TITLE
Add Python 3.13 to CI and declared support

### DIFF
--- a/.github/workflows/build-docs-version.yml
+++ b/.github/workflows/build-docs-version.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.11'
+            python-version: '3.13'
 
       - name: Get tag
         id: tag

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.11'
+            python-version: '3.13'
 
       - run: sudo apt-get install xvfb
 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install dependencies
       run: python -m pip install --upgrade pip setuptools build
     - name: Build sdist and wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           docker build -f bin/Dockerfile \
-            --build-arg PYTHON_VERSION=3.12 \
+            --build-arg PYTHON_VERSION=3.13 \
             --tag minari-docker .
       - name: Run tests
         run: docker run minari-docker pytest tests/* -k "not test_docs.py and not integrations"

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.11'
+            python-version: '3.13'
 
       - name: Install Minari
         run: pip install .[all,testing]

--- a/.github/workflows/manual-build-docs-version.yml
+++ b/.github/workflows/manual-build-docs-version.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.11'
+            python-version: '3.13'
 
       - run: sudo apt-get install xvfb
 

--- a/.github/workflows/manual-build-publish.yml
+++ b/.github/workflows/manual-build-publish.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install dependencies
       run: python -m pip install --upgrade pip setuptools build
     - name: Build sdist and wheels

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.11'
+            python-version: '3.13'
       - run: pip install pre-commit
       - run: pre-commit --version
       - run: pre-commit run --all-files

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.11'
+            python-version: '3.13'
 
       - name: Install Minari
         run: pip install .[all,testing,integrations]

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -28,7 +28,7 @@ cd Minari
 pip install -e ".[all]"
 ```
 
-We support Python with minimum version 3.8 on Linux and macOS.
+We support Python 3.8 through 3.13 on Linux and macOS.
 
 ## Using Minari Datasets
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ]


### PR DESCRIPTION
# Description

This change adds **Python 3.13** to the declared support surface and runs CI (GitHub Actions and the Docker test image) on **3.13**, while keeping **`requires-python >= 3.8`**.

- **pyproject.toml**: add the `Programming Language :: Python :: 3.13` classifier; keep existing 3.8–3.12 classifiers.
- **CI**: set `actions/setup-python` and Docker `PYTHON_VERSION` to 3.13.
- **Docs**: state support for **Python 3.8 through 3.13** in basic usage.

Branch is based on current **upstream** `main` (`Farama-Foundation/Minari`).

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
