### PR TITLE
docs: fix Python version badge to track minari instead of gymnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python](https://img.shields.io/pypi/pyversions/gymnasium.svg)](https://badge.fury.io/py/gymnasium)
+[![Python](https://img.shields.io/pypi/pyversions/minari.svg)](https://badge.fury.io/py/minari)
 [![build](https://github.com/Farama-Foundation/Minari/actions/workflows/build.yml/badge.svg)](https://github.com/Farama-Foundation/Minari/actions)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
# Description

The README "Python" version badge pointed at **Gymnasium's** PyPI metadata — the image source was `https://img.shields.io/pypi/pyversions/gymnasium.svg` and it linked to `https://badge.fury.io/py/gymnasium` — so Minari's README displayed Gymnasium's supported Python versions instead of Minari's own.

This change points both the badge image and its link at the `minari` package. The badge now resolves to Minari's actual supported versions from its `pyproject.toml` classifiers (`3.8 | 3.9 | 3.10 | 3.11 | 3.12`) rather than Gymnasium's (`3.10 | 3.11 | 3.12 | 3.13`).

Fixes #329

## Type of change

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

> The README's first badge (rendered text):
> - **Before:** `python  3.10 | 3.11 | 3.12 | 3.13`  ← Gymnasium's versions
> - **After:**  `python  3.8 | 3.9 | 3.10 | 3.11 | 3.12`  ← Minari's versions (matches `pyproject.toml` classifiers)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present. <!-- N/A: documentation-only change (README badge URL); no code paths affected -->
- [ ] I have commented my code, particularly in hard-to-understand areas <!-- N/A: no code changed -->
- [ ] I have made corresponding changes to the documentation <!-- N/A: this change *is* the documentation fix -->
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge. <!-- N/A: no code changed -->
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- N/A: a unit test for a README badge URL is not idiomatic here; verified via live shields.io resolution, which now returns Minari's 3.8–3.12 -->
- [ ] New and existing unit tests pass locally with my changes <!-- N/A: documentation-only change -->
