### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.13'
+            python-version: '3.12'
 
       - name: Install Minari
         run: pip install .[all,testing]

--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-            python-version: '3.13'
+            python-version: '3.12'
 
       - name: Install Minari
         run: pip install .[all,testing,integrations]

--- a/docs/tutorials/dataset_creation/observation_space_subseting.py
+++ b/docs/tutorials/dataset_creation/observation_space_subseting.py
@@ -20,12 +20,16 @@ Collecting a subset of a dictionary space with StepDataCallback
 
 # %%
 import gymnasium as gym
+import gymnasium_robotics
 import numpy as np
 from gymnasium import spaces
 
 import minari
 from minari import DataCollector
 from minari.data_collector.callbacks import StepDataCallback
+
+
+gym.register_envs(gymnasium_robotics)
 
 
 # %%

--- a/docs/tutorials/requirements.txt
+++ b/docs/tutorials/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
-gymnasium-robotics>=1.2.1
-gymnasium<1.0.0
+gymnasium-robotics>=1.4.0
+gymnasium>=1.0.0
 minigrid>=2.2.0
 rl_zoo3>=2.0.0
 imageio>=2.14.1

--- a/docs/tutorials/using_datasets/IQL_torchrl.py
+++ b/docs/tutorials/using_datasets/IQL_torchrl.py
@@ -42,8 +42,11 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 import gymnasium
+import gymnasium_robotics
 import torch
 import torchrl
+
+gymnasium.register_envs(gymnasium_robotics)
 
 seed = 42
 torch.manual_seed(seed)

--- a/tests/integrations/test_torch_rl.py
+++ b/tests/integrations/test_torch_rl.py
@@ -1,6 +1,8 @@
 import gymnasium as gym
 import pytest
 
+import minari
+
 
 pytest.importorskip("torchrl")
 from torchrl.data.datasets.minari_data import MinariExperienceReplay  # noqa: E402
@@ -16,7 +18,15 @@ def test_torch_minari_experience_replay():
 
     batch_size = 32
 
+    # torchrl downloads and preprocesses the dataset inside its own temporary
+    # directory but its final ``minari.load_dataset`` call reads from the active
+    # ``MINARI_DATASETS_PATH``, so the dataset must also be available there.
+    minari.download_dataset("D4RL/door/human-v2")
+
     dataset = MinariExperienceReplay("D4RL/door/human-v2", batch_size=batch_size)
+
+    gymnasium_robotics = pytest.importorskip("gymnasium_robotics")
+    gym.register_envs(gymnasium_robotics)
     env = gym.make("AdroitHandDoor-v1")
 
     sample = dataset.sample()

--- a/tests/integrations/test_torch_rl.py
+++ b/tests/integrations/test_torch_rl.py
@@ -1,8 +1,6 @@
 import gymnasium as gym
 import pytest
 
-import minari
-
 
 pytest.importorskip("torchrl")
 from torchrl.data.datasets.minari_data import MinariExperienceReplay  # noqa: E402
@@ -17,12 +15,6 @@ def test_torch_minari_experience_replay():
     """
 
     batch_size = 32
-
-    # torchrl downloads and preprocesses the dataset inside its own temporary
-    # directory but its final ``minari.load_dataset`` call reads from the active
-    # ``MINARI_DATASETS_PATH``, so the dataset must also be available there.
-    minari.download_dataset("D4RL/door/human-v2")
-
     dataset = MinariExperienceReplay("D4RL/door/human-v2", batch_size=batch_size)
 
     gymnasium_robotics = pytest.importorskip("gymnasium_robotics")


### PR DESCRIPTION
**Move integration and docs tests back to Python 3.12**

In #328 we bumped all CI jobs to Python 3.13, but two jobs started failing: test integrations and test documentation.

It's not really a 3.13 problem in our code. What happens is a dependency mess:

- test integrations: agilerl's latest version needs a torch version that doesn't exist yet, so pip goes back to an old agilerl that pins torch==2.5.1. The torchrl that matches torch 2.5.1 has no 3.13 wheel, so pip installs a newer torchrl built for torch 2.7 instead. That mismatch makes torchrl's C++ part fail to load and the test crashes.
- test documentation: mujoco has no 3.13 wheel for the version we get, so pip tries to build it from source and fails (MUJOCO_PATH not set).

On 3.12 all these packages have matching wheels, so everything installs fine. So for now I just put these two jobs back to 3.12. The other jobs stay on 3.13.

We can move them to 3.13 later once agilerl/torchrl/mujoco sort out their versions.