### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -33,6 +33,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
     - build-wheels
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Minari/security/code-scanning/1](https://github.com/Farama-Foundation/Minari/security/code-scanning/1)

Add an explicit `permissions` block to the `publish` job in `.github/workflows/build-publish.yml`, granting only the minimum needed scope.  
The least-invasive fix is to add:

```yml
permissions:
  contents: read
```

under `publish` (same indentation level as `runs-on`, `needs`, `if`, `steps`). This preserves existing behavior while satisfying CodeQL’s requirement that token permissions be explicitly limited. No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
