### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-build-publish.yml
+++ b/.github/workflows/manual-build-publish.yml
@@ -31,6 +31,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
     - build-wheels
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Minari/security/code-scanning/2](https://github.com/Farama-Foundation/Minari/security/code-scanning/2)

Add an explicit `permissions` block to the `publish` job in `.github/workflows/manual-build-publish.yml`, matching least privilege for the job’s current behavior. Since `publish` only downloads artifacts and uploads to PyPI via an API token secret (not repo writes), the safest non-breaking setting is:

- `permissions: {}`
  
This explicitly grants no `GITHUB_TOKEN` scopes for that job, preventing inherited broad permissions and satisfying the static analysis requirement. No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
