### PR TITLE
Fix latest_version filtering in list_remote_datasets

### DIFF
--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -222,12 +222,14 @@ def list_remote_datasets(
 
         if latest_version:
             namespace, dataset_name, version = parse_dataset_id(dataset_id)
-            old_version = max_version[namespace].get(dataset_name, version)
-            max_version[namespace][dataset_name] = max(old_version, version)
-            if old_version != max_version[namespace][dataset_name]:
-                min_id = gen_dataset_id(
-                    namespace, dataset_name, min(old_version, version)
-                )
-                del remote_datasets[min_id]
+            prev_version = max_version[namespace].get(dataset_name)
+            if prev_version is None or version > prev_version:
+                if prev_version is not None:
+                    del remote_datasets[
+                        gen_dataset_id(namespace, dataset_name, prev_version)
+                    ]
+                max_version[namespace][dataset_name] = version
+            else:
+                del remote_datasets[dataset_id]
 
     return remote_datasets

--- a/minari/storage/hosting.py
+++ b/minari/storage/hosting.py
@@ -229,7 +229,7 @@ def list_remote_datasets(
                         gen_dataset_id(namespace, dataset_name, prev_version)
                     ]
                 max_version[namespace][dataset_name] = version
-            else:
+            elif version < prev_version:
                 del remote_datasets[dataset_id]
 
     return remote_datasets

--- a/tests/test_hosting.py
+++ b/tests/test_hosting.py
@@ -1,0 +1,86 @@
+from typing import Iterable, List, Optional
+
+import pytest
+
+from minari.storage import hosting
+
+
+class FakeCloudStorage:
+    """Minimal in-memory CloudStorage, to test listing without any remote."""
+
+    def __init__(self, dataset_ids: List[str]):
+        self.dataset_ids = dataset_ids
+
+    def list_datasets(self, prefix: Optional[str] = None) -> Iterable[str]:
+        for dataset_id in self.dataset_ids:
+            if prefix is None or dataset_id.startswith(prefix):
+                yield dataset_id
+
+    def get_dataset_metadata(self, dataset_id: str) -> dict:
+        return {"dataset_id": dataset_id}
+
+
+@pytest.fixture
+def patch_cloud_storage(monkeypatch):
+    def patch(dataset_ids: List[str]):
+        monkeypatch.setattr(
+            hosting, "get_cloud_storage", lambda **_: FakeCloudStorage(dataset_ids)
+        )
+
+    return patch
+
+
+@pytest.mark.parametrize(
+    "dataset_ids",
+    [
+        ["D4RL/door/human-v0", "D4RL/door/human-v1", "D4RL/door/human-v2"],
+        ["D4RL/door/human-v2", "D4RL/door/human-v1", "D4RL/door/human-v0"],
+        ["D4RL/door/human-v1", "D4RL/door/human-v0", "D4RL/door/human-v2"],
+        ["D4RL/door/human-v2", "D4RL/door/human-v0", "D4RL/door/human-v1"],
+    ],
+)
+def test_list_remote_datasets_latest_version_ignores_listing_order(
+    patch_cloud_storage, dataset_ids: List[str]
+):
+    """Only the highest version is returned, whatever order the remote lists them in.
+
+    The remote gives no ordering guarantee: GCS lists blobs lexicographically
+    (so `-v10` comes before `-v2`) and the Hugging Face API lists repos in
+    arbitrary order.
+    """
+    patch_cloud_storage(dataset_ids)
+
+    remote_datasets = hosting.list_remote_datasets(latest_version=True)
+
+    assert list(remote_datasets.keys()) == ["D4RL/door/human-v2"]
+    assert remote_datasets["D4RL/door/human-v2"]["dataset_id"] == "D4RL/door/human-v2"
+
+
+def test_list_remote_datasets_latest_version_per_dataset(patch_cloud_storage):
+    """Versions are tracked per (namespace, dataset name), not globally."""
+    patch_cloud_storage(
+        [
+            "D4RL/door/human-v10",  # sorts before -v2 lexicographically
+            "D4RL/door/human-v2",
+            "D4RL/door/expert-v0",
+            "atari/pong/expert-v1",
+            "atari/pong/expert-v0",
+        ]
+    )
+
+    remote_datasets = hosting.list_remote_datasets(latest_version=True)
+
+    assert set(remote_datasets.keys()) == {
+        "D4RL/door/human-v10",
+        "D4RL/door/expert-v0",
+        "atari/pong/expert-v1",
+    }
+
+
+def test_list_remote_datasets_all_versions(patch_cloud_storage):
+    dataset_ids = ["D4RL/door/human-v1", "D4RL/door/human-v0"]
+    patch_cloud_storage(dataset_ids)
+
+    remote_datasets = hosting.list_remote_datasets()
+
+    assert set(remote_datasets.keys()) == set(dataset_ids)


### PR DESCRIPTION
`list_remote_datasets(latest_version=True)` only pruned a dataset when the incoming version raised the running maximum, but every dataset was added to the result before that check. A version lower than one already seen left the maximum unchanged, so the older dataset stayed in the result.