### PR TITLE
Raise the intended error when a space type has no deserializer

### DIFF
--- a/minari/serialization.py
+++ b/minari/serialization.py
@@ -111,7 +111,12 @@ def _serialize_text(space: spaces.Text, to_string=True) -> Union[Dict, str]:
 
 class type_value_dispatch:
     def __init__(self, func) -> None:
-        self.registry = defaultdict(func)
+        # `defaultdict` calls its factory with no arguments, so the factory has
+        # to return the fallback rather than be it. Passing `func` straight in
+        # called it without `space_dict`, and an unregistered type raised a
+        # TypeError about the missing argument instead of the NotImplementedError
+        # the fallback is written to raise.
+        self.registry = defaultdict(lambda: func)
 
     def register(self, type: str):
         def decorator(method):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -25,3 +25,17 @@ def test_space_serialize_deserialize_unsupported(space):
         NotImplementedError, match=r"No serialization method available for .+"
     ):
         serialize_space(space)
+
+
+@pytest.mark.parametrize("space_type", ["Graph", "Sequence", "OneOf"])
+def test_space_deserialize_unsupported(space_type):
+    """Deserializing an unregistered type reports it the way serializing does.
+
+    The two directions used to disagree: `serialize_space` raised the
+    NotImplementedError below, while `deserialize_space` raised a TypeError
+    about a missing argument, from inside the dispatch table.
+    """
+    with pytest.raises(
+        NotImplementedError, match=r"No deserialization method available for .+"
+    ):
+        deserialize_space({"type": space_type})


### PR DESCRIPTION
## Description

`deserialize_space` reports an unregistered space type with the wrong error:

```python
>>> from minari.serialization import deserialize_space
>>> deserialize_space({"type": "Graph"})
TypeError: deserialize_space() missing 1 required positional argument: 'space_dict'
```

`type_value_dispatch` builds its table as `defaultdict(func)`. `defaultdict`
calls its factory with no arguments, so `func` — the fallback, which takes
`space_dict` — was invoked without it. The `NotImplementedError` it is written
to raise never got the chance:

```python
@type_value_dispatch
def deserialize_space(space_dict: Dict) -> spaces.Space:
    raise NotImplementedError(
        f"No deserialization method available for {space_dict['type']}"
    )
```

The factory now returns the fallback rather than being it, and the message
names the type that has no deserializer.

The two directions disagreed until now: `serialize_space` is a `singledispatch`
and reports unsupported spaces correctly, which is what
`test_space_serialize_deserialize_unsupported` covers. Nothing exercised the
deserializing direction, so this went unnoticed.

## Tests

`tests/test_serialization.py` gains `test_space_deserialize_unsupported`,
parametrised over `Graph`, `Sequence` and `OneOf` — three Gymnasium spaces with
no deserializer registered. All three fail on `main` with the `TypeError` above
and pass here; the file goes from 19 to 22 passing.

`pre-commit run` is clean on both files. `tests/test_namespace.py` fails 9 cases
here both with and without this change — they reach the remote storage, and the
baseline is the same.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
