### PR TITLE
Carry the dtype of a Discrete space through a round trip

### DIFF
--- a/minari/serialization.py
+++ b/minari/serialization.py
@@ -5,8 +5,16 @@ from collections import defaultdict
 from functools import singledispatch
 from typing import Dict, Union
 
+import gymnasium
 import numpy as np
 from gymnasium import spaces
+
+
+# `Discrete` only gained a `dtype` argument in Gymnasium 1.3.0, and this package
+# supports 0.28.1 upwards, so the argument is passed only from 1.3.0 onwards.
+_DISCRETE_ACCEPTS_DTYPE = tuple(
+    int(part) for part in gymnasium.__version__.split(".")[:2]
+) >= (1, 3)
 
 
 @singledispatch
@@ -33,7 +41,7 @@ def _serialize_box(space: spaces.Box, to_string=True) -> Union[Dict, str]:
 def _serialize_discrete(space: spaces.Discrete, to_string=True) -> Union[Dict, str]:
     result = {}
     result["type"] = "Discrete"
-    result["dtype"] = "int64"  # this seems to be hardcoded in Gymnasium
+    result["dtype"] = str(space.dtype)
     # we need to cast from np.int64 to python's int type in order to serialize
     result["start"] = int(space.start)
     result["n"] = int(space.n)
@@ -169,6 +177,16 @@ def _deserialize_discrete(space_dict: Dict) -> spaces.Discrete:
     assert space_dict["type"] == "Discrete"
     n = space_dict["n"]
     start = space_dict["start"]
+    dtype = space_dict.get("dtype", "int64")
+
+    if _DISCRETE_ACCEPTS_DTYPE:
+        return spaces.Discrete(n=n, start=start, dtype=dtype)
+
+    if np.dtype(dtype) != np.dtype("int64"):
+        raise ValueError(
+            f"The dataset declares a Discrete space of dtype {dtype}, which needs "
+            f"Gymnasium 1.3.0 or later; {gymnasium.__version__} is installed."
+        )
     return spaces.Discrete(n=n, start=start)
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,12 @@
+import gymnasium as gym
+import numpy as np
 import pytest
 
-from minari.serialization import deserialize_space, serialize_space
+from minari.serialization import (
+    _DISCRETE_ACCEPTS_DTYPE,
+    deserialize_space,
+    serialize_space,
+)
 from tests.common import test_spaces, unsupported_test_spaces
 
 
@@ -25,3 +31,24 @@ def test_space_serialize_deserialize_unsupported(space):
         NotImplementedError, match=r"No serialization method available for .+"
     ):
         serialize_space(space)
+
+
+@pytest.mark.skipif(
+    not _DISCRETE_ACCEPTS_DTYPE,
+    reason="`spaces.Discrete` only takes a dtype from Gymnasium 1.3.0",
+)
+@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+def test_discrete_keeps_its_dtype(dtype):
+    """A `Discrete` space must come back with the dtype it was written with.
+
+    The serializer wrote `"int64"` regardless and the deserializer ignored the
+    field, so a space built with another dtype came back as a different space.
+    The round-trip test above compares the two serialized strings rather than
+    the spaces, which is why it did not notice.
+    """
+    space = gym.spaces.Discrete(5, start=-2, dtype=dtype)
+
+    reconstructed = deserialize_space(serialize_space(space))
+
+    assert reconstructed.dtype == space.dtype
+    assert reconstructed == space


### PR DESCRIPTION
## Description

`_serialize_discrete` writes `"int64"` for every `Discrete` space and
`_deserialize_discrete` ignores the field, so a space built with another dtype
comes back as a different space:

```python
space = spaces.Discrete(5, dtype=np.int32)
reconstructed = deserialize_space(serialize_space(space))

reconstructed.dtype     # int64
reconstructed == space  # False
```

The comment on the line — `# this seems to be hardcoded in Gymnasium` — was
true when it was written. `Discrete` gained a `dtype` argument in Gymnasium
1.3.0, and `DiscreteArray`-style specs that default to int32 are common enough
that a dataset can carry one.

`test_space_serialize_deserialize` compares the two serialized strings rather
than the two spaces, so it stays green either way. That is why this went
unnoticed.

## Changes

* Serialising writes `str(space.dtype)`. No version guard is needed there:
  `Discrete.dtype` exists on every supported Gymnasium and is int64 on the
  older ones, which is exactly what was written before, so old and new files
  agree.

* Deserialising passes the dtype from Gymnasium 1.3.0 onwards. `pyproject.toml`
  declares `gymnasium>=0.28.1`, so on an older install a dataset that asks for
  a narrower dtype is reported:

  ```
  ValueError: The dataset declares a Discrete space of dtype int32, which needs
  Gymnasium 1.3.0 or later; 1.2.0 is installed.
  ```

  Silently widening it would hand back a space the dataset never described.
  Every file written before this change says int64, which matches the default,
  so nothing existing hits that path.

The version check is the same shape as the one in
Farama-Foundation/Shimmy#157: major and minor compared as integers rather than
as strings, so 1.10 stays above 1.3, and no dependency on `packaging`, which
is not in this project's requirements.

## Tests

`test_discrete_keeps_its_dtype`, parametrised over int32 and int64. The int32
case fails on `main` and passes here; int64 passes either way, which is where
the two defaults coincide. The case is skipped with a reason below Gymnasium
1.3.0. `tests/test_serialization.py` is 21 passed, `pre-commit run` clean on
both files.

#345 touches the same two files, so whichever of the two lands second will need
a rebase — say the word and I will push it.
